### PR TITLE
Ceci update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ log.txt
 outputs/*.hdf
 outputs/*.sacc
 outputs/*.fits
+.ropeproject

--- a/test/config.yml
+++ b/test/config.yml
@@ -6,7 +6,7 @@ TXPhotozPDF:
 TXSelector:
     T_cut: 0.5
     s2n_cut: 10.0
-    rows: 1000
+    max_rows: 1000
     delta_gamma: 0.02
     zbin_edges: [0.3, 0.5, 0.7, 0.9, 2.0]
     chunk_rows: 1000
@@ -17,7 +17,7 @@ TXDiagnosticMaps:
     snr_threshold: 5.0
     snr_delta: 1.0
     # pixelization: healpix
-    # nside: 2048       # 
+    # nside: 2048       #
     pixelization: tangent
     ra_min: 36.34
     ra_max: 36.57

--- a/test/setup-cori
+++ b/test/setup-cori
@@ -1,8 +1,8 @@
-#!/usr/bin/echo "Please source this file from the main pipette directory: source ./bin/setup-cori   (ignore rest of this line)"
+#!/usr/bin/echo "Please source this file from the main Ceci directory: source ./bin/setup-cori   (ignore rest of this line)"
 module swap PrgEnv-intel  PrgEnv-gnu
 module unload darshan
 module load hdf5-parallel/1.10.1
 module load python/3.6-anaconda-4.4
 module load cfitsio/3.370-reentrant
 source activate /global/projecta/projectdirs/lsst/groups/WL/users/zuntz/env
-export PYTHONPATH=$PYTHONPATH:$PWD:$PWD/../pipette:/$PWD/../DESCFormats
+export PYTHONPATH=$PYTHONPATH:$PWD:$PWD/../ceci:/$PWD/../DESCFormats

--- a/txpipe/photoz.py
+++ b/txpipe/photoz.py
@@ -19,7 +19,7 @@ class TXPhotozPDF(PipelineStage):
     ]
 
     # Configuration options.  If the value is not "None" then it specifies a default value
-    config_options = {'zmax': None, 'nz': None, 'chunk_rows': 10000}
+    config_options = {'zmax': float, 'nz': int, 'chunk_rows': 10000}
 
 
     def run(self):

--- a/txpipe/selector.py
+++ b/txpipe/selector.py
@@ -7,7 +7,7 @@ def select(shear_data, pz_data, cuts, variant):
 
     s2n_cut = cuts['T_cut']
     T_cut = cuts['s2n_cut']
-    
+
     s2n_col = 'mcal_T' + variant
     T_col = 'mcal_s2n_r' + variant
     z_col = 'mu' + variant
@@ -50,7 +50,8 @@ class TXSelector(PipelineStage):
     outputs = [
         ('tomography_catalog', TomographyCatalog)
     ]
-    config_options = {'T_cut':float, 's2n_cut':float, 'delta_gamma': float, 'max_rows':0, 'chunk_rows':10000}
+    config_options = {'T_cut':float, 's2n_cut':float, 'delta_gamma': float, 'max_rows':0,
+                      'chunk_rows':10000, 'zbin_edges':[float]}
 
     def run(self):
         import numpy as np
@@ -100,7 +101,7 @@ class TXSelector(PipelineStage):
 
 
     def calculate_tomography(self, pz_data, shear_data, info):
-        # for each tomographic bin, select objects in that bin 
+        # for each tomographic bin, select objects in that bin
         # under each metacal choice
         import numpy as np
 
@@ -165,13 +166,13 @@ class TXSelector(PipelineStage):
 
 
         S = 0.0
-        N = 0 
+        N = 0
 
         for S_i, count in selection_biases:
             S += count[:,np.newaxis,np.newaxis]*S_i
             N += count
             # count (4) S_i (4,2,2)
-        # For each bin 
+        # For each bin
         for i,n_i in enumerate(N):
             S[i]/=n_i
 

--- a/txpipe/selector.py
+++ b/txpipe/selector.py
@@ -50,7 +50,7 @@ class TXSelector(PipelineStage):
     outputs = [
         ('tomography_catalog', TomographyCatalog)
     ]
-    config_options = {'T_cut':None, 's2n_cut':None, 'delta_gamma': None, 'max_rows':0, 'chunk_rows':10000}
+    config_options = {'T_cut':float, 's2n_cut':float, 'delta_gamma': float, 'max_rows':0, 'chunk_rows':10000}
 
     def run(self):
         import numpy as np

--- a/txpipe/sysmaps.py
+++ b/txpipe/sysmaps.py
@@ -32,10 +32,10 @@ class TXDiagnosticMaps(PipelineStage):
     config_options = {
         'pixelization': 'healpix', # The pixelization scheme to use, currently just healpix
         'nside':0,   # The Healpix resolution parameter for the generated maps
-        'snr_threshold':None,  # The S/N value to generate maps for (e.g. 5 for 5-sigma depth)
+        'snr_threshold':float,  # The S/N value to generate maps for (e.g. 5 for 5-sigma depth)
         'snr_delta':1.0,  # The range threshold +/- delta is used for finding objects at the boundary
         'chunk_rows':100000,  # The number of rows to read in each chunk of data at a time
-        'sparse':None,   # Whether to generate sparse maps - faster and less memory for small sky areas
+        'sparse':bool,   # Whether to generate sparse maps - faster and less memory for small sky areas
     }
 
 

--- a/txpipe/sysmaps.py
+++ b/txpipe/sysmaps.py
@@ -21,13 +21,13 @@ class TXDiagnosticMaps(PipelineStage):
         ('shear_catalog', MetacalCatalog),
         ('config', YamlFile),
     ]
-    
+
     # We generate a single HDF file in this stage
     # containing all the maps
     outputs = [
         ('diagnostic_maps', DiagnosticMaps),
     ]
-    
+
     # Configuration information for this stage
     config_options = {
         'pixelization': 'healpix', # The pixelization scheme to use, currently just healpix
@@ -35,7 +35,12 @@ class TXDiagnosticMaps(PipelineStage):
         'snr_threshold':float,  # The S/N value to generate maps for (e.g. 5 for 5-sigma depth)
         'snr_delta':1.0,  # The range threshold +/- delta is used for finding objects at the boundary
         'chunk_rows':100000,  # The number of rows to read in each chunk of data at a time
-        'sparse':bool,   # Whether to generate sparse maps - faster and less memory for small sky areas
+        'sparse':bool,   # Whether to generate sparse maps - faster and less memory for small sky areas,
+        'ra_min':float,  #
+        'ra_max':float,  # RA range
+        'dec_min':float, #
+        'dec_max':float, # DEC range
+        'pixel_size':float # Pixel size of pixelization scheme
     }
 
 
@@ -55,15 +60,15 @@ class TXDiagnosticMaps(PipelineStage):
 
         # Set up the iterator to run through the FITS file.
         # Iterators lazily load the data chunk by chunk as we iterate through the file.
-        # We don't need to use the start and end points in this case, as 
+        # We don't need to use the start and end points in this case, as
         # we're not making a new catalog.
         cat_cols = ['ra', 'dec', 'mcal_s2n_r', 'mcal_mag']
         data_iterator = (data for start,end,data in self.iterate_fits('shear_catalog', 1, cat_cols, config['chunk_rows']))
 
 
         # Calculate the depth map, map of the counts used in computing the depth map, and map of the depth variance
-        pixel, count, depth, depth_var = dr1_depth(data_iterator, 
-            pixel_scheme, config['snr_threshold'], config['snr_delta'], sparse=config['sparse'], 
+        pixel, count, depth, depth_var = dr1_depth(data_iterator,
+            pixel_scheme, config['snr_threshold'], config['snr_delta'], sparse=config['sparse'],
             comm=self.comm)
 
         # Only the root process saves the output


### PR DESCRIPTION
Minor update to make TXPipe compatible with new Ceci convention on config_options without default values. This is compatible with https://github.com/LSSTDESC/ceci/tree/cwl and related to https://github.com/LSSTDESC/ceci/pull/2

It's just a matter of replacing config_options without defaults to the expected type, instead of just None e.g.:
```
-    config_options = {'T_cut':None, 's2n_cut':None, 'delta_gamma': None, 'max_rows':0, 'chunk_rows':10000, 'zbin_edges':None}
+    config_options = {'T_cut':float, 's2n_cut':float, 'delta_gamma': float, 'max_rows':0,
+                      'chunk_rows':10000, 'zbin_edges':[float]}
```

Should only be merged if and when https://github.com/LSSTDESC/ceci/pull/2 gets merged