### PR TITLE
Stages/input cats

### DIFF
--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -27,7 +27,7 @@ To run the example you need some input data files.  You can obtain these from
 NERSC if you have access to the LSST space using:
 
 `` 
-    scp USERNAME@cori.nersc.gov:/global/projecta/projectdirs/lsst/groups/WL/users/zuntz/data/tract008766-shear-cat-0-10000.fits ./
+    scp USERNAME@cori.nersc.gov:/global/projecta/projectdirs/lsst/groups/WL/users/zuntz/data/* ./
 ``
 
 

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -27,5 +27,14 @@ To run the example you need some input data files.  You can obtain these from
 NERSC if you have access to the LSST space using:
 
 `` 
-    scp USERNAME@cori.nersc.gov:/global/projecta/projectdirs/lsst/groups/WL/users/zuntz/tract008766-shear-cat-0-10000.fits ./
+    scp USERNAME@cori.nersc.gov:/global/projecta/projectdirs/lsst/groups/WL/users/zuntz/data/tract008766-shear-cat-0-10000.fits ./
 ``
+
+
+To set up an environment with the required dependencies for this code on the cori machine at NERSC, run:
+``
+    source /global/projecta/projectdirs/lsst/groups/WL/users/zuntz/setup-cori
+    # OR
+    source /global/projecta/projectdirs/lsst/groups/WL/users/zuntz/setup-cori-nompi
+``
+use the former when running jobs and the latter on the login nodes.

--- a/test/config.yml
+++ b/test/config.yml
@@ -1,3 +1,5 @@
+TXDProtoDC2Mock:
+    max_size: 100000
 TXRandomPhotozPDF:
     nz: 301
     zmax: 3.0

--- a/test/config.yml
+++ b/test/config.yml
@@ -2,6 +2,7 @@ TXRandomPhotozPDF:
     nz: 301
     zmax: 3.0
     chunk_rows: 1000
+    bands: ugriz
 
 TXPhotozStack:
     chunk_rows: 1000

--- a/test/config.yml
+++ b/test/config.yml
@@ -1,5 +1,4 @@
-TXDProtoDC2Mock:
-    max_size: 100000
+TXDProtoDC2Mock: {}
 TXRandomPhotozPDF:
     nz: 301
     zmax: 3.0

--- a/test/config.yml
+++ b/test/config.yml
@@ -1,4 +1,4 @@
-TXDProtoDC2Mock: {}
+TXProtoDC2Mock: {}
 TXRandomPhotozPDF:
     nz: 301
     zmax: 3.0

--- a/test/phot.yaml
+++ b/test/phot.yaml
@@ -6,7 +6,7 @@ modules: txpipe
 
 
 stages:
-    - name: TXDProtoDC2Mock
+    - name: TXProtoDC2Mock
       nprocess: 1
     - name: TXSelector
       nprocess: 1

--- a/test/phot.yaml
+++ b/test/phot.yaml
@@ -1,6 +1,6 @@
-#launcher: local
+launcher: local
 # To run on cori use:
-launcher: cori-interactive
+#launcher: cori-interactive
 
 modules: txpipe
 
@@ -9,9 +9,9 @@ stages:
     - name: TXDProtoDC2Mock
       nprocess: 1
     - name: TXSelector
-      nprocess: 32
+      nprocess: 1
     - name: TXRandomPhotozPDF
-      nprocess: 32
+      nprocess: 1
 # These don't work yet - stuff missing from metacal sim:
 #    - name: TXDiagnosticMaps
 #      nprocess: 1

--- a/test/phot.yaml
+++ b/test/phot.yaml
@@ -11,8 +11,8 @@ stages:
 # These don't work yet - stuff missing from metacal sim:
     - name: TXSelector
       nprocess: 1
-#    - name: TXRandomPhotozPDF
-#      nprocess: 1
+   - name: TXRandomPhotozPDF
+     nprocess: 1
 #    - name: TXDiagnosticMaps
 #      nprocess: 1
 #    - name: TXPhotozStack

--- a/test/phot.yaml
+++ b/test/phot.yaml
@@ -1,0 +1,37 @@
+launcher: local
+# To run on cori use:
+# launcher: cori
+
+modules: txpipe
+
+
+stages:
+    - name: TXDProtoDC2Mock
+      nprocess: 1
+# These don't work yet - stuff missing from metacal sim:
+    - name: TXSelector
+      nprocess: 1
+#    - name: TXRandomPhotozPDF
+#      nprocess: 1
+#    - name: TXDiagnosticMaps
+#      nprocess: 1
+#    - name: TXPhotozStack
+#      nprocess: 1
+
+output_dir: ./outputs2
+
+config: test/config.yml
+
+inputs:
+  # full data file:
+  # shear_catalog: /global/projecta/projectdirs/lsst/groups/WL/users/esheldon/ngmixer-outputs/test-medsdm-dbcoadd-mcal-001/combined/tract008766-test-medsdm-dbcoadd-mcal-001.fits
+  # path to partial data file on NERSC:
+  # /global/projecta/projectdirs/lsst/groups/WL/users/zuntz/tract008766-shear-cat-0-10000.fits
+  # Local, assuming you have downloaded as in doc/installation.rst
+  #  shear_catalog: ./tract008766-shear-cat-0-10000.fits
+    response_model: /global/projecta/projectdirs/lsst/groups/WL/users/zuntz/data/DESY1-R-model.hdf
+    
+resume: False
+log_dir: ./test/logs
+pipeline_log: log.txt
+

--- a/test/phot.yaml
+++ b/test/phot.yaml
@@ -11,8 +11,8 @@ stages:
 # These don't work yet - stuff missing from metacal sim:
     - name: TXSelector
       nprocess: 1
-   - name: TXRandomPhotozPDF
-     nprocess: 1
+    - name: TXRandomPhotozPDF
+      nprocess: 1
 #    - name: TXDiagnosticMaps
 #      nprocess: 1
 #    - name: TXPhotozStack

--- a/test/phot.yaml
+++ b/test/phot.yaml
@@ -12,11 +12,10 @@ stages:
       nprocess: 1
     - name: TXRandomPhotozPDF
       nprocess: 1
-# These don't work yet - stuff missing from metacal sim:
-#    - name: TXDiagnosticMaps
-#      nprocess: 1
-#    - name: TXPhotozStack
-#      nprocess: 1
+    - name: TXDiagnosticMaps
+      nprocess: 1
+    - name: TXPhotozStack
+      nprocess: 1
 
 output_dir: ./outputs2
 
@@ -31,7 +30,7 @@ inputs:
   #  shear_catalog: ./tract008766-shear-cat-0-10000.fits
     response_model: /global/projecta/projectdirs/lsst/groups/WL/users/zuntz/data/DESY1-R-model.hdf
     
-resume: False
+resume: True
 log_dir: ./test/logs
 pipeline_log: log.txt
 

--- a/test/phot.yaml
+++ b/test/phot.yaml
@@ -1,6 +1,6 @@
-launcher: local
+#launcher: local
 # To run on cori use:
-# launcher: cori
+launcher: cori-interactive
 
 modules: txpipe
 
@@ -8,11 +8,11 @@ modules: txpipe
 stages:
     - name: TXDProtoDC2Mock
       nprocess: 1
-# These don't work yet - stuff missing from metacal sim:
     - name: TXSelector
-      nprocess: 1
+      nprocess: 32
     - name: TXRandomPhotozPDF
-      nprocess: 1
+      nprocess: 32
+# These don't work yet - stuff missing from metacal sim:
 #    - name: TXDiagnosticMaps
 #      nprocess: 1
 #    - name: TXPhotozStack

--- a/txpipe/__init__.py
+++ b/txpipe/__init__.py
@@ -11,4 +11,4 @@ from .photoz_stack import TXPhotozStack
 from .random_cats import TXRandomCat
 from .sysmaps import TXDiagnosticMaps
 from .twopoint import TXTwoPoint
-
+from .input_cats import TXDProtoDC2Mock

--- a/txpipe/__init__.py
+++ b/txpipe/__init__.py
@@ -11,4 +11,4 @@ from .photoz_stack import TXPhotozStack
 from .random_cats import TXRandomCat
 from .sysmaps import TXDiagnosticMaps
 from .twopoint import TXTwoPoint
-from .input_cats import TXDProtoDC2Mock
+from .input_cats import TXProtoDC2Mock

--- a/txpipe/input_cats.py
+++ b/txpipe/input_cats.py
@@ -244,6 +244,7 @@ def make_mock_photometry(n_visit, bands, data):
     for band, b_b, t_b, n_eff in zip(bands, B_b, T_b, N_eff):
         # truth magnitude
         mag = data[f'mag_true_{band}_lsst']
+        output[f'mag_true_{band}_lsst'] = mag
 
         # expected signal photons, over all visits
         c_b = factor * 10**(0.4*(25-mag)) * t_b * n_visit

--- a/txpipe/input_cats.py
+++ b/txpipe/input_cats.py
@@ -6,26 +6,35 @@ from descformats.tx import MetacalCatalog, HDFFile
 
 class TXDProtoDC2Mock(PipelineStage):
     """
+    This stage simulates metacal data and metacalibrated
+    photometry measurements, starting from a cosmology catalogs
+    of the kind used as an input to DC2 image and obs-catalog simulations.
 
-
+    This is mainly useful for testing infrastructure in advance
+    of the DC2 catalogs being available, but might also be handy
+    for starting from a purer simulation.
     """
     name='TXDProtoDC2Mock'
+
     inputs = [
         ('response_model', HDFFile)
     ]
+
     outputs = [
         ('shear_catalog', MetacalCatalog),
         ('photometry_catalog', HDFFile),
     ]
+
     config_options = {
-        'cat_name':'protoDC2_test', 
-        'visits_per_band':165, 
-        'snr_limit':4.0,
-        'max_size': 99999999999999
+        'cat_name':'protoDC2_test',
+        'visits_per_band':165,  # used in the noise simulation
+        'snr_limit':4.0,  # used to decide what objects to cut out
+        'max_size': 99999999999999  #for testing on smaller catalogs
         }
 
     def data_iterator(self, gc):
 
+        # Columns we need from the cosmo simulation
         cols = ['mag_true_u_lsst', 'mag_true_g_lsst', 
                 'mag_true_r_lsst', 'mag_true_i_lsst', 
                 'mag_true_z_lsst',
@@ -41,13 +50,28 @@ class TXDProtoDC2Mock(PipelineStage):
             yield data
 
     def get_catalog_size(self, gc):
+        """
+        Get the size of a GCR catalog object.
+        This is not robust - catalogs can be split over
+        multiple files.  As of now there is no API for this.
+
+        Parameters
+        ----------
+
+        gc: GCRCatalogs catalog object
+
+        Returns
+        -------
+        n: integer
+            Number of catalog rows
+        """
         import h5py
         filename = gc.get_catalog_info()['filename']
         print(f"Reading catalog size directly from {filename}")
+        # Take the name of a specific column we expect to exist
         f = h5py.File(filename)
         n = f['galaxyProperties/ra'].size
         f.close()
-        n = min(n, self.config['max_size'])
         return n
 
     def run(self):
@@ -55,27 +79,47 @@ class TXDProtoDC2Mock(PipelineStage):
         cat_name = self.config['cat_name']
         self.bands = ('u','g', 'r', 'i', 'z')
 
+        # Load the input catalog (this is lazy)
         gc = GCRCatalogs.load_catalog(cat_name)
+
+        # Get the size, and optionally cut down to a smaller
+        # size if we want to test
         N = self.get_catalog_size(gc)
-        self.cat_size = N
+        self.cat_size = min(N, self.config['max_size'])
+
+        # Prepare output files
         metacal_file = self.open_output('shear_catalog', clobber=True)
         photo_file = self.open_output('photometry_catalog', parallel=False)
-
-        # This is the kind of thing that should go into
-        # the DESCFormats stuff
         self.setup_photometry_output(photo_file)
+
+        # Load the metacal response file
         self.load_metacal_response_model()
+
+        # Keep track of catalog position
         self.current_index = 0
+
+        # Loop through chunks of 
         for data in self.data_iterator(gc):
+            # Cut down the chunk of data if we exceed our desired
+            # catlog size
             if len(data['galaxy_id'])+self.current_index > self.cat_size:
                 cut = self.cat_size - self.current_index
                 for name in list(data.keys()):
                     data[name] = data[name][:cut]
+
+            # Simulate the various output data sets
             mock_photometry = self.make_mock_photometry(data)
             mock_metacal = self.make_mock_metacal(data, mock_photometry)
+
+            # Cut out any objects too faint to be detected and measured
             self.remove_undetected(mock_photometry, mock_metacal)
+
+            # Save all output
             self.write_photometry(photo_file, mock_photometry)
             self.write_metacal(metacal_file, mock_metacal)
+
+            # Break early if we are cutting down the
+            # catalog
             if self.current_index >= self.cat_size:
                 break
 
@@ -116,6 +160,17 @@ class TXDProtoDC2Mock(PipelineStage):
     
 
     def load_metacal_response_model(self):
+        """
+        Load an HDF file containing the response model
+        R(log10(snr), size)
+        R_std(log10(snr), size)
+
+        where R is the mean metacal response in a bin and
+        R_std is its standard deviation.
+
+        So far only one of these files exists!
+
+        """
         import scipy.interpolate
         import numpy as np
         model_file = self.open_input("response_model")
@@ -125,12 +180,25 @@ class TXDProtoDC2Mock(PipelineStage):
         R_std = model_file['R_model/R_std'][:]
         model_file.close()
 
+        # Save a 2D spline
         snr_grid, sz_grid = np.meshgrid(snr_centers, sz_centers)
         self.R_spline=scipy.interpolate.SmoothBivariateSpline(snr_grid.T.flatten(), sz_grid.T.flatten(), R_mean.flatten(), w=R_std.flatten())
         self.Rstd_spline=scipy.interpolate.SmoothBivariateSpline(snr_grid.T.flatten(), sz_grid.T.flatten(), R_std.flatten())        
 
 
     def write_photometry(self, photo_file, mock_photometry):
+        """
+        Save the photometry we have just simulated to disc
+
+        Parameters
+        ----------
+
+        photo_file: HDF File object
+
+        mock_photometry: dict
+            Dictionary of simulated photometry
+
+        """
         # Work out the range of data to output (since we will be
         # doing this in chunks)
         start = self.current_index
@@ -145,15 +213,37 @@ class TXDProtoDC2Mock(PipelineStage):
         self.current_index += n
 
     def write_metacal(self, metacal_file, metacal_data):
+        """
+        Save the metacal data we have just simulated to disc
+
+        Parameters
+        ----------
+
+        metacal_file: fitsio FITS File object
+
+        metacal_data: dict
+            Dictionary of arrays of simulated metacal values
+
+        """
         import numpy as np
+
+        # Get the name and data type for eah column
+        # We sort these so that they are always in the same order,
+        # because we will just be appending the data for
+        # subsequent calls
         dtype = [(name,val.dtype,val[0].shape) for (name,val) in sorted(metacal_data.items())]
         nobj = metacal_data['R'].size
+
+        # Make a numpy structured array for this data
+        # and fill it in with our values
         data = np.zeros(nobj, dtype)
         for key, val in metacal_data.items():
             data[key] = val
 
+        # The first time we call this we will make an extension
+        # to contain the data.  Subsequent times we just append
+        # to that extension.
         already_created_ext = len(metacal_file)==2
-
         if already_created_ext:
             metacal_file[-1].append(data)
         else:
@@ -172,24 +262,23 @@ class TXDProtoDC2Mock(PipelineStage):
 
     def make_mock_metacal(self, data, photo):
         """
-        Generate a mock metacal table with noise added
+        Generate a mock metacal table.
+        This is a long and complicated function unfortunately.
+
+        Throughout we assume a single R = R11 = R22, with R12 = R21 = 0
+        
+        Parameters
+        ----------
+        data: dict
+            Dictionary of arrays read from the input cosmo catalog
+        photo: dict
+            Dictionary of arrays generated to simulate photometry
         """
 
-        # TODO: Write
 
         # These are the numbers from figure F1 of the DES Y1 shear catalog paper
         # (this version is not yet public but is awaiting a second referee response)
         import numpy as np
-
-        # strategy here.
-        # we have a S/N per band for each object.
-        # get the total S/N in r,i,z since most shapes are measured there.
-        # if it's > 5 then make a fake R_mean value based on the signal to noise and size
-        # Then generate R_mean from R with some spread
-        # 
-        # Just use the true shear * R_mean for the estimated shear
-        # (the noise on R will do the job of noise on shear)
-        # Use R11 = R22 and R12 = R21 = 0
 
         # Overall SNR for the three bands usually used for shape measurement
         # We use the true SNR not the estimated one, though these are pretty close
@@ -203,62 +292,89 @@ class TXDProtoDC2Mock(PipelineStage):
 
         log10_snr = np.log10(snr)
 
+        # Convert from the half-light radius which is in the 
+        # input catalogs to a sigma.  Do this by pretending
+        # that it is a Gaussian.  This is clearly wrong, and
+        # if this causes major errors in the size cuts we may
+        # have to modify this
         size_hlr = data['size_true']
         size_sigma = size_hlr / np.sqrt(2*np.log(2))
         size_T = 2 * size_sigma**2
 
+        # Use a fixed PSF across all the objects
         psf_fwhm = 0.75
         psf_sigma = psf_fwhm/(2*np.sqrt(2*np.log(2)))
         psf_T = 2 * psf_sigma**2
 
+        # Use the response model to get a reasonable response
+        # value for this size and SNR
         R_mean = self.R_spline(log10_snr, size_T, grid=False)
         R_std = self.Rstd_spline(log10_snr, size_T, grid=False)
         
-
-#        response_mean = np.array([R_mean, R_mean])
-        rho = 0.2  # correlation between size response and shear response.  chosen arbitrarily
-#        response_covmat = np.array([[R_std**2,rho*R_std**2],[rho*R_std**2,R_std**2]])
-#        R, R_size = R_mean + np.random.multivariate_normal(response_mean, response_covmat, nobj).T
+        # Assume a 0.2 correlation between the size response
+        # and the shear response.
+        rho = 0.2
         f = np.random.multivariate_normal([0.0,0.0], [[1.0,rho],[rho,1.0]], nobj).T
         R, R_size = f * R_std + R_mean
 
+        # Convert magnitudes to fluxes according to the baseline
+        # use in the metacal numbers
         flux_r = 10**0.4*(27 - photo['mag_r_lsst'])
         flux_i = 10**0.4*(27 - photo['mag_i_lsst'])
         flux_z = 10**0.4*(27 - photo['mag_z_lsst'])
 
+        # Note that this is delta_gamma not 2*delta_gamma, because
+        # of how we use it below
         delta_gamma = 0.01
         
+        # Use a fixed shape noise per component to generate 
+        # an overall 
         shape_noise = 0.26
         eps  = np.random.normal(0,shape_noise,nobj) + 1.j * np.random.normal(0,shape_noise,nobj)
+        # True shears without shape noise
         g1 = data['shear_1']
         g2 = data['shear_2']
+        # Do the full combination of (g,epsilon) -> e, not the approx one
         g = g1 + 1j*g2
         e = (eps + g) / (1+g.conj()*eps)
         e1 = e.real
         e2 = e.imag
-       
-
+    
+        # Now collect together everything to go into the metacal
+        # file
         output = {
+            # Basic values
             "R":R,
             'id': photo['id'],
             'ra': photo['ra'],
             'dec': photo['dec'],
+            # Keep the truth value just in case
             "true_g": np.array([g1, g2]).T,
+            # Shears, taken by scaling the overall ellipticity by the response
+            # I think this is the correct thing to use here
             "mcal_g": np.array([e1*R, e2*R]).T,
+            # metacalibrated variants - we add the shear and then 
+            # apply the response
             "mcal_g_1p": np.array([(e1+delta_gamma)*R, e2*R]).T,
             "mcal_g_1m": np.array([(e1-delta_gamma)*R, e2*R]).T,
             "mcal_g_2p": np.array([e1*R, (e2+delta_gamma)*R]).T,
             "mcal_g_2m": np.array([e1*R, (e2-delta_gamma)*R]).T,
+            # Size parameter and metacal variants
             "mcal_T": size_T,
             "mcal_T_1p": size_T + R_size*delta_gamma,
             "mcal_T_1m": size_T - R_size*delta_gamma,
             "mcal_T_2p": size_T + R_size*delta_gamma,
             "mcal_T_2m": size_T - R_size*delta_gamma,
+            # Rounded SNR values, as used in the selection,
+            # together with the metacal variants
             "mcal_s2n_r": snr,
             "mcal_s2n_r_1p": snr_1p,
             "mcal_s2n_r_1m": snr_1m,
             "mcal_s2n_r_2p": snr_2p,
             "mcal_s2n_r_2m": snr_2m,
+            # Magntiudes and fluxes, just copied from the inputs.
+            # Note that we won't use these directly later as we instead
+            # use stuff from the photometry file
             'mcal_mag': np.array([photo['mag_r_lsst'], photo['mag_i_lsst'], photo['mag_z_lsst']]).T,
             'mcal_flux': np.array([flux_r, flux_i, flux_z]).T,
             # not sure if this is right
@@ -266,15 +382,29 @@ class TXDProtoDC2Mock(PipelineStage):
             # mcal_weight appears to be all zeros in the tract files.
             # possibly they should in fact all be ones.
             'mcal_weight': np.zeros(nobj),
-            'mcal_gpsf': np.zeros(nobj),
+            # Fixed PSF parameters - all round with same size
+            'mcal_gpsf': np.zeros(nobj,2),
             'mcal_Tpsf': np.repeat(psf_T, nobj),
-            'mcal_flags': np.repeat(0, nobj),
+            # Everything that gets this far should be used, so flag=0
+            'mcal_flags': np.zeros(nobj, dtype=int),
+            # Pretend these are the same as the standard sizes
+            # actually they are measured on a rounded version
+            "mcal_T_r": size_T,
+            "mcal_T_r_1p": size_T + R_size*delta_gamma,
+            "mcal_T_r_1m": size_T - R_size*delta_gamma,
+            "mcal_T_r_2p": size_T + R_size*delta_gamma,
+            "mcal_T_r_2m": size_T - R_size*delta_gamma,
             # Everything below here is wrong
+            # Some of these are probably important!
+            # For now I'm leaving them all as zero 
+            # because we're not currently using them in the
+            # main pipeline
             "mcal_g_cov": np.zeros((nobj,2,2)),
             "mcal_g_cov_1p": np.zeros((nobj,2,2)),
             "mcal_g_cov_1m": np.zeros((nobj,2,2)),
             "mcal_g_cov_2p": np.zeros((nobj,2,2)),
             "mcal_g_cov_2m": np.zeros((nobj,2,2)),
+            # These are fit parameters and their covariances
             "mcal_pars":np.zeros((nobj,6)),
             "mcal_pars_1p":np.zeros((nobj,6)),
             "mcal_pars_1m":np.zeros((nobj,6)),
@@ -286,16 +416,13 @@ class TXDProtoDC2Mock(PipelineStage):
             "mcal_pars_cov_2p":np.zeros((nobj,6,6)),
             "mcal_pars_cov_2m":np.zeros((nobj,6,6)),
             "mcal_flux_cov": np.zeros((nobj,2,2)),
+            # This is likely to be important
             "mcal_T_err": np.zeros(nobj),
             "mcal_T_err_1p": np.zeros(nobj),
             "mcal_T_err_1m": np.zeros(nobj),
             "mcal_T_err_2p": np.zeros(nobj),
             "mcal_T_err_2m": np.zeros(nobj),
-            "mcal_T_r": size_T,
-            "mcal_T_r_1p": size_T,
-            "mcal_T_r_1m": size_T,
-            "mcal_T_r_2p": size_T,
-            "mcal_T_r_2m": size_T,
+            # Surface brightness
             "mcal_logsb": np.zeros(nobj),
 
             }
@@ -305,8 +432,18 @@ class TXDProtoDC2Mock(PipelineStage):
 
 
     def remove_undetected(self, photo, metacal):
+        """
+        Strip out any undetected objects from the two
+        simulated data sets.
+
+        Use a configuration parameter snr_limit to decide
+        on the detection limit.
+        """
         import numpy as np
         snr_limit = self.config['snr_limit']
+
+        # This will become a boolean array in a minute when
+        # we OR it with an array
         detected = False
 
         # Check if detected in any band.  Makes a boolean array
@@ -331,13 +468,14 @@ class TXDProtoDC2Mock(PipelineStage):
 
         detected &= (~zero_shear_edge)
 
+        # Print out interesting information
         ndet = detected.sum()
         ntot = detected.size
         fract = ndet*100./ntot
-
         print(f"Detected {ndet} out of {ntot} objects ({fract:.1f}%)")
+
         # Remove all objects not detected in *any* band
-        # make a copy of the keys with photo.keys so we are not
+        # make a copy of the keys with list(photo.keys()) so we are not
         # modifying during the iteration
         for key in list(photo.keys()): 
             photo[key] = photo[key][detected]
@@ -347,6 +485,13 @@ class TXDProtoDC2Mock(PipelineStage):
 
 
     def truncate_photometry(self, photo_file):
+        """
+        Cut down the output photometry file to its final 
+        size.
+
+        Not sure why I did this as the size should be
+        the same.  I must have had a reason.
+        """
         group = photo_file['photometry']
         cols = list(group.keys())
         for col in cols:
@@ -447,6 +592,7 @@ def make_mock_photometry(n_visit, bands, data):
         output[f'mag_{band}_lsst_2p'] = mag_obs_2p
         output[f'mag_{band}_lsst_2m'] = mag_obs_2m
 
+        # Scale the SNR values according the to change in magnitude.r
         output[f'snr_{band}_1p'] = obs_snr * 10**(0.4*(mag_obs - mag_obs_1p))
         output[f'snr_{band}_1m'] = obs_snr * 10**(0.4*(mag_obs - mag_obs_1m))
         output[f'snr_{band}_2p'] = obs_snr * 10**(0.4*(mag_obs - mag_obs_2p))

--- a/txpipe/input_cats.py
+++ b/txpipe/input_cats.py
@@ -137,6 +137,7 @@ class TXProtoDC2Mock(PipelineStage):
             cols.append(f'mag_true_{band}_lsst')
             cols.append(f'true_snr_{band}')
             cols.append(f'mag_{band}_lsst')
+            cols.append(f'mag_err_{band}_lsst')
             cols.append(f'mag_{band}_lsst_1p')
             cols.append(f'mag_{band}_lsst_1m')
             cols.append(f'mag_{band}_lsst_2p')
@@ -383,7 +384,7 @@ class TXProtoDC2Mock(PipelineStage):
             # possibly they should in fact all be ones.
             'mcal_weight': np.zeros(nobj),
             # Fixed PSF parameters - all round with same size
-            'mcal_gpsf': np.zeros(nobj,2),
+            'mcal_gpsf': np.zeros((nobj,2)),
             'mcal_Tpsf': np.repeat(psf_T, nobj),
             # Everything that gets this far should be used, so flag=0
             'mcal_flags': np.zeros(nobj, dtype=int),

--- a/txpipe/input_cats.py
+++ b/txpipe/input_cats.py
@@ -1,0 +1,171 @@
+from ceci import PipelineStage
+from descformats.tx import MetacalCatalog, HDFFile
+
+# could also just load /global/projecta/projectdirs/lsst/groups/CS/descqa/catalog/ANL_AlphaQ_v3.0.hdf5
+
+
+class TXDProtoDC2Mock(PipelineStage):
+    """
+
+
+    """
+    name='TXDProtoDC2Mock'
+    inputs = [
+    ]
+    outputs = [
+        ('metacal_catalog', MetacalCatalog),
+        ('photometry_catalog', HDFFile),
+    ]
+    config_options = {'cat_name':'protoDC2_test', 'visits_per_band':165}
+
+    def data_iterator(self, gc):
+
+        cols = ['mag_true_u_lsst', 'mag_true_g_lsst', 
+                'mag_true_r_lsst', 'mag_true_i_lsst', 
+                'mag_true_z_lsst',
+                'ellipticity_1_true', 'ellipticity_2_true',
+                'shear_1', 'shear_2',
+                'size_true',
+                'galaxy_id',
+                ]
+
+        it = gc.get_quantities(cols, return_iterator=True)
+        for data in it:
+            yield data
+
+    def get_catalog_size(self, gc):
+        f = h5py.File(gc.get_catalog_info()['filename'])
+        n = ['galaxyProperties/ra'].size
+        f.close()
+        return n
+
+    def run(self):
+        import GCRCatalogs
+        cat_name = self.config['cat_name']
+        gc = GCRCatalogs.load_catalog(cat_name)
+        N = self.get_size(gc)
+
+        metacal_file = self.open_output('metacal_catalog', parallel=False)
+        photo_file = self.open_output('photometry_catalog', parallel=False)
+
+
+        start = 0
+        for data in self.data_iterator(gc):
+            end = start + len(data.values()[0])
+
+            mock_photometry = self.make_mock_photometry(data)
+            mock_metacal = self.make_mock_metacal(data, mock_photometry)
+
+            self.write_photometry(photo_file, mock_photometry, start, end)
+            self.write_metacal(metacal_file, mock_metacal, start, end)
+
+
+
+    def make_mock_photometry(self, data):
+        bands = ('u','g', 'r', 'i', 'z')
+        n_visit = self.config['visits_per_band']
+        photo = make_mock_photometry(n_visit, bands, data)
+        return photo
+
+    def make_mock_metacal(self, data, photo):
+        """
+        Generate a mock metacal table with noise added
+        """
+        # These are the numbers from figure F1 of the DES Y1 shear catalog paper
+        # (this version is not yet public but is awaiting a second referee response)
+        import numpy as np
+        import scipy.interpolate
+
+        # strategy here.
+        # we have a S/N per band for each object.
+        # get the total S/N in r,i,z since most shapes are measured there.
+        # if it's > 5 then make a fake R_mean value based on the signal to noise and size
+        # Then generate R_mean from R with some spread
+        # 
+        # Just use the true shear * R_mean for the estimated shear
+        # (the noise on R will do the job of noise on shear)
+        # Use R11 = R22 and R12 = R21 = 0
+
+        # wasteful - we are making this every chunk of data
+        spline_snr = np.log10([0.01,  5.7,   7.4,   9.7,  12.6,  16.5,  21.5,  28. ,  36.5,  47.5,
+                    61.9,  80.7, 105.2, 137.1, 178.7, 232.9, 303.6, 395.7, 515.7,
+                    672.1, 875.9])
+        spline_R = array([0.001,  0.07, 0.15, 0.25, 0.35, 0.43, 0.5 , 0.54, 0.56, 0.58, 0.59, 0.59,
+                    0.6 , 0.6 , 0.59, 0.57, 0.55, 0.52, 0.5 , 0.48, 0.46])
+
+        spline = scipy.interpolate.interp1d(spline_snr, spline_R, kind='cubic')
+
+        # Now we need the SNR of the object.
+
+
+
+
+def make_mock_photometry(n_visit, bands, data):
+    """
+    Generate a mock photometric table with noise added
+
+    This is mostly from LSE‐40 by 
+    Zeljko Ivezic, Lynne Jones, and Robert Lupton
+    retrieved here:
+    http://faculty.washington.edu/ivezic/Teaching/Astr511/LSST_SNRdoc.pdf
+    """
+
+    import numpy as np
+
+
+    # Sky background, seeing, and system throughput, 
+    # all from table 2 of Ivezic, Jones, & Lupton
+    B_b = np.array([85.07, 467.9, 1085.2, 1800.3, 2775.7])
+    fwhm = np.array([0.77, 0.73, 0.70, 0.67, 0.65])
+    T_b = np.array([0.0379, 0.1493, 0.1386, 0.1198, 0.0838])
+
+
+    # effective pixels size for a Gaussian PSF, from equation
+    # 27 of Ivezic, Jones, & Lupton
+    pixel = 0.2 # arcsec
+    N_eff = 2.436 * (fwhm/pixel)**2
+
+
+    # other numbers from Ivezic, Jones, & Lupton
+    sigma_inst2 = 10.0**2  #instrumental noise in photons per pixel, just below eq 42
+    gain = 1  # ADU units per photon, also just below eq 42
+    D = 8.4 # primary mirror diameter in meters, from LSST key numbers page
+    time = 30. # seconds per exposure, from LSST key numbers page
+    sigma_b2 = 0.0 # error on background, just above eq 42
+
+    # combination of these  used below, from various equations
+    factor = 5455./gain * (D/6.5)**2 * (time/30)
+
+    for band, b_b, t_b, n_eff in zip(bands, B_b, T_b, N_eff):
+        # truth magnitude
+        mag = data[f'mag_true_{band}_lsst']
+
+        # expected signal photons, over all visits
+        c_b = factor * 10**(0.4*(25-mag)) * t_b * n_visit
+
+        # expectedbackground photons, over all visits
+        background = (b_b + sigma_inst2 + sigma_b2)*n_eff * n_visit
+        # total expected photons
+        mu = c_b + background
+        
+        # Observed number of photons in excess of the expected background.
+        # This can go negative for faint magnitudes, indicating that the object is
+        # not going to be detected
+        n_obs = np.random.poisson(mu) - background
+
+        # signal to noise, true and estimated values
+        true_snr = mu / background**0.5
+        obs_snr = n_obs / background
+
+        # observed magnitude from inverting c_b expression above
+        mag_obs = 25 - 2.5*np.log10(n_obs/factor/t_b)
+
+        visible = np.isfinite(mag_obs)
+
+        output[f'true_snr_{band}'] = true_snr
+        output[f'snr_{band}'] = obs_snr
+        output[f'mag_{band}_lsst'] = mag_obs
+
+    return output
+
+

--- a/txpipe/input_cats.py
+++ b/txpipe/input_cats.py
@@ -570,6 +570,7 @@ def make_mock_photometry(n_visit, bands, data):
         # This can go negative for faint magnitudes, indicating that the object is
         # not going to be detected
         n_obs = np.random.poisson(mu) - background
+        n_obs_err = np.sqrt(mu)
 
         # signal to noise, true and estimated values
         true_snr = c_b / background
@@ -578,9 +579,13 @@ def make_mock_photometry(n_visit, bands, data):
         # observed magnitude from inverting c_b expression above
         mag_obs = 25 - 2.5*np.log10(n_obs/factor/t_b/n_visit)
 
+        # converting error on n_obs to error on mag
+        mag_err = -2.5*np.log10(np.e)*(n_obs_err/n_obs)
+
         output[f'true_snr_{band}'] = true_snr
         output[f'snr_{band}'] = obs_snr
         output[f'mag_{band}_lsst'] = mag_obs
+        output[f'mag_err_{band}_lsst'] = mag_err
 
         mag_obs_1p = mag_obs + mag_resp*delta_gamma
         mag_obs_1m = mag_obs - mag_resp*delta_gamma

--- a/txpipe/input_cats.py
+++ b/txpipe/input_cats.py
@@ -1,5 +1,5 @@
 from ceci import PipelineStage
-from descformats.tx import MetacalCatalog, HDFFile, DataFile
+from descformats.tx import MetacalCatalog, HDFFile
 
 # could also just load /global/projecta/projectdirs/lsst/groups/CS/descqa/catalog/ANL_AlphaQ_v3.0.hdf5
 

--- a/txpipe/input_cats.py
+++ b/txpipe/input_cats.py
@@ -64,7 +64,7 @@ class TXDProtoDC2Mock(PipelineStage):
         # This is the kind of thing that should go into
         # the DESCFormats stuff
         self.setup_photometry_output(photo_file)
-        self.load_metacal_R_model()
+        self.load_metacal_response_model()
         self.current_index = 0
         for data in self.data_iterator(gc):
             if len(data['galaxy_id'])+self.current_index > self.cat_size:
@@ -115,7 +115,7 @@ class TXDProtoDC2Mock(PipelineStage):
         group.create_dataset('galaxy_id', (self.cat_size,), maxshape=(self.cat_size,), dtype='i8')
     
 
-    def load_metacal_R_model(self):
+    def load_metacal_response_model(self):
         import scipy.interpolate
         import numpy as np
         model_file = self.open_input("response_model")
@@ -267,10 +267,32 @@ class TXDProtoDC2Mock(PipelineStage):
             'mcal_Tpsf': np.repeat(psf_T, nobj),
             # Everything below here is wrong
             "mcal_g_cov": np.zeros((nobj,2,2)),
+            "mcal_g_cov_1p": np.zeros((nobj,2,2)),
+            "mcal_g_cov_1m": np.zeros((nobj,2,2)),
+            "mcal_g_cov_2p": np.zeros((nobj,2,2)),
+            "mcal_g_cov_2m": np.zeros((nobj,2,2)),
+            "mcal_pars":np.zeros((nobj,6)),
+            "mcal_pars_1p":np.zeros((nobj,6)),
+            "mcal_pars_1m":np.zeros((nobj,6)),
+            "mcal_pars_2p":np.zeros((nobj,6)),
+            "mcal_pars_2m":np.zeros((nobj,6)),
+            "mcal_pars_cov":np.zeros((nobj,6,6)),
+            "mcal_pars_cov_1p":np.zeros((nobj,6,6)),
+            "mcal_pars_cov_1m":np.zeros((nobj,6,6)),
+            "mcal_pars_cov_2p":np.zeros((nobj,6,6)),
+            "mcal_pars_cov_2m":np.zeros((nobj,6,6)),
             "mcal_flux_cov": np.zeros((nobj,2,2)),
             "mcal_T_err": np.zeros(nobj),
+            "mcal_T_err_1p": np.zeros(nobj),
+            "mcal_T_err_1m": np.zeros(nobj),
+            "mcal_T_err_2p": np.zeros(nobj),
+            "mcal_T_err_2m": np.zeros(nobj),
             "mcal_T_r": size_T,
-            "mcal_log_sb": np.zeros(nobj),
+            "mcal_T_r_1p": size_T,
+            "mcal_T_r_1m": size_T,
+            "mcal_T_r_2p": size_T,
+            "mcal_T_r_2m": size_T,
+            "mcal_logsb": np.zeros(nobj),
 
             }
 

--- a/txpipe/input_cats.py
+++ b/txpipe/input_cats.py
@@ -542,13 +542,9 @@ def make_mock_photometry(n_visit, bands, data):
     # combination of these  used below, from various equations
     factor = 5455./gain * (D/6.5)**2 * (time/30.)
 
-    nband = len(bands)
-    mu = np.zeros(nband) # seems approx mean of response across bands, from HSC tract
-    rho = 0.25  #  approx correlation between response in bands, from HSC tract
-    sigma2 = 1.7**2 # approx variance of response, from HSC tract
-    covmat = np.full((nband,nband), rho*sigma2)
-    np.fill_diagonal(covmat, sigma2)
-    mag_responses = np.random.multivariate_normal(mu, covmat, nobj).T
+    # Fake some metacal responses
+    mag_responses = generate_mock_metacal_mag_responses(bands, nobj)
+
     delta_gamma = 0.01  # this is the half-delta gamma, i.e. gamma_+ - gamma_0
     # that's the right thing to use here because we are doing m+ = m0 + dm/dy*dy
     # Use the same response for gamma1 and gamma2
@@ -606,6 +602,182 @@ def make_mock_photometry(n_visit, bands, data):
 
 
     return output
+
+
+
+def generate_mock_metacal_mag_responses(bands, nobj):
+    import numpy as np
+    nband = len(bands)
+    mu = np.zeros(nband) # seems approx mean of response across bands, from HSC tract
+    rho = 0.25  #  approx correlation between response in bands, from HSC tract
+    sigma2 = 1.7**2 # approx variance of response, from HSC tract
+    covmat = np.full((nband,nband), rho*sigma2)
+    np.fill_diagonal(covmat, sigma2)
+    mag_responses = np.random.multivariate_normal(mu, covmat, nobj).T
+    return mag_responses
+
+class TXDRPMockMetacal(PipelineStage):
+    """
+    Use real photometry from the DRP (output of DM stack) in merged form,
+    but fake metacal responses for the magnitudes.
+
+    TODO: Shapes!
+    """
+    name = "TXDRPMockMetacal"
+
+    inputs = [
+        ('response_model', HDFFile),
+        ('drp_merged_cat', HDFFile)
+    ]
+
+    outputs = [
+        ('shear_catalog', MetacalCatalog),
+        ('photometry_catalog', HDFFile),
+    ]
+
+    config_options = {
+        'cat_name':'protoDC2_test',
+        'visits_per_band':165,  # used in the noise simulation
+        'snr_limit':4.0,  # used to decide what objects to cut out
+        'max_size': 99999999999999  #for testing on smaller catalogs
+        }
+
+    @staticmethod
+    def count_pandas_rows(filename):
+        """
+        Count the number of rows in a Pandas format catalog,
+        as used by the merged DRP catalog.
+
+        Pandas saves things in an odd packed format, and offers
+        no way to check the size of the catalog before reading it in.
+
+        Additionally there are many different sub-catalogs.
+
+        Parameters
+        ----------
+        Filename: str
+            name of the HDF format file
+
+        Returns
+        -------
+
+        count: int
+            Number of rows in all the sub-catalogs
+
+        """
+        import h5py
+        f = h5py.File(filename, "r")
+        extensions = [ext for ext in f.keys() if ext.startswith('coadd_')]
+        count = 0
+        for ext in extensions:
+            ext = f[ext]
+            nb = ext.attrs['nblocks']
+            for i in range(nb):
+                count += len(ext[f'block{i}_values'])
+        f.close()
+        return count
+
+
+
+
+    def run(self):
+        #input_filename="/global/cscratch1/sd/jchiang8/desc/HSC/merged_tract_8524.hdf5"
+        input_drp = self.get_input('drp_merged_cat')
+        output_photo = self.open_output('photometry_catalog')
+
+        n = self.count_pandas_rows(input_drp)
+        print(f"Found {n} objects in catalog {input_drp}")
+
+        # Put everything under the "photometry" section
+        photo = output.create_group('photometry')
+
+        # The merged DRP file is already split into chunks internally - we load those 
+        # chunks one by one
+        for (start,end, data) in self.generate_fake_metacalibrated_photometry(input_drp):
+
+            # For the first chunk we create the output data space, 
+            # because then we know what all the columns are
+            if start==0:
+                for colname,col in data.items():
+                    photo.create_dataset(colname, (n,), dtype=col.dtype)
+                    print(f" Column: {colname}")
+
+            # Output this chunk
+            print(f" Saving rows {start}:{end}")
+            for colname,col in data.items():
+                photo[colname][start:end] = col
+
+        output.close()
+
+
+    def generate_fake_metacalibrated_photometry(self, filename):
+        import h5py
+        import pandas
+        import warnings
+
+        bands =  'grizy'
+
+        # Find all the sub-catalogs
+        f = h5py.File(filename, "r")
+        extensions = [ext for ext in f.keys() if ext.startswith('coadd_')]
+        f.close()
+
+        # this is the half-delta gamma, i.e. gamma_+ - gamma_0
+        delta_gamma = 0.01
+
+        # Location in output file
+        start = 0
+
+        for ext in extensions:
+            output = {}
+            print(f"Reading extension {ext}")
+            cat = pandas.read_hdf(filename, key=ext)
+            n = len(cat)
+
+            # Generate some mock metacal responses for the magnitudes.
+            # This is until we get real ones
+            warnings.warn("Faking metacal responses for magnitudes")
+            mag_responses = generate_mock_metacal_mag_responses(bands, n)
+            end = start + n
+
+            # Right now these are all called HSC, because that's the tract file 
+            # we are looking at.  Should update to use GCR which will abstract
+            # these names away, when this is ready
+            for band, mag_resp in zip(bands, mag_responses):
+                BAND = band.upper()
+
+                # Mags and SNR are in the catalog already
+                warnings.warn("Pretending that HSC filters are the same as LSST")
+                mag_obs = cat[f'HSC-{BAND}_mag']
+                snr     = cat[f'HSC-{BAND}_SNR']
+                mag_err = cat[f'HSC-{BAND}_mag_err']
+
+                output[f'mag_{band}_lsst']     = mag_obs
+                output[f'snr_{band}']          = snr
+                output[f'mag_err_{band}_lsst'] = mag_err
+
+                # Generate the metacalibrated values
+                mag_obs_1p = mag_obs + mag_resp*delta_gamma
+                mag_obs_1m = mag_obs - mag_resp*delta_gamma
+                mag_obs_2p = mag_obs + mag_resp*delta_gamma
+                mag_obs_2m = mag_obs - mag_resp*delta_gamma
+
+                # Save them, but we will also need them to generate
+                # metacalibrated SNRs below
+                output[f'mag_{band}_lsst_1p'] = mag_obs_1p
+                output[f'mag_{band}_lsst_1m'] = mag_obs_1m
+                output[f'mag_{band}_lsst_2p'] = mag_obs_2p
+                output[f'mag_{band}_lsst_2m'] = mag_obs_2m
+
+                # Scale the SNR values according the to change in magnitude.
+                output[f'snr_{band}_1p'] = snr * 10**(0.4*(mag_obs - mag_obs_1p))
+                output[f'snr_{band}_1m'] = snr * 10**(0.4*(mag_obs - mag_obs_1m))
+                output[f'snr_{band}_2p'] = snr * 10**(0.4*(mag_obs - mag_obs_2p))
+                output[f'snr_{band}_2m'] = snr * 10**(0.4*(mag_obs - mag_obs_2m))
+
+            # Yield this chunk of catalog
+            yield start, end, output
+            start = end
 
 
 

--- a/txpipe/input_cats.py
+++ b/txpipe/input_cats.py
@@ -112,7 +112,7 @@ class TXDProtoDC2Mock(PipelineStage):
             group.create_dataset(col, (self.cat_size,), maxshape=(self.cat_size,), dtype='f8')
 
         # The only non-float column for now
-        group.create_dataset('galaxy_id', (self.cat_size,), maxshape=(self.cat_size,), dtype='i8')
+        group.create_dataset('id', (self.cat_size,), maxshape=(self.cat_size,), dtype='i8')
     
 
     def load_metacal_response_model(self):
@@ -134,7 +134,7 @@ class TXDProtoDC2Mock(PipelineStage):
         # Work out the range of data to output (since we will be
         # doing this in chunks)
         start = self.current_index
-        n = len(mock_photometry['galaxy_id'])
+        n = len(mock_photometry['id'])
         end = start + n
 
         # Save each column
@@ -240,6 +240,9 @@ class TXDProtoDC2Mock(PipelineStage):
 
         output = {
             "R":R,
+            'id': photo['id'],
+            'ra': photo['ra'],
+            'dec': photo['dec'],
             "true_g": np.array([g1, g2]).T,
             "mcal_g": np.array([e1*R, e2*R]).T,
             "mcal_g_1p": np.array([(e1+delta_gamma)*R, e2*R]).T,
@@ -366,7 +369,7 @@ def make_mock_photometry(n_visit, bands, data):
     nobj = data['galaxy_id'].size
     output['ra'] = data['ra']
     output['dec'] = data['dec']
-    output['galaxy_id'] = data['galaxy_id']
+    output['id'] = data['galaxy_id']
 
 
     # Sky background, seeing FWHM, and system throughput, 

--- a/txpipe/input_cats.py
+++ b/txpipe/input_cats.py
@@ -263,7 +263,7 @@ def make_mock_photometry(n_visit, bands, data):
         obs_snr = n_obs / background
 
         # observed magnitude from inverting c_b expression above
-        mag_obs = 25 - 2.5*np.log10(n_obs/factor/t_b)
+        mag_obs = 25 - 2.5*np.log10(n_obs/factor/t_b/n_visit)
 
         output[f'true_snr_{band}'] = true_snr
         output[f'snr_{band}'] = obs_snr

--- a/txpipe/input_cats.py
+++ b/txpipe/input_cats.py
@@ -260,11 +260,12 @@ class TXDProtoDC2Mock(PipelineStage):
             'mcal_flux': np.array([flux_r, flux_i, flux_z]).T,
             # not sure if this is right
             'mcal_flux_s2n': np.array([photo['snr_r'], photo['snr_i'], photo['snr_z']]).T,
-            # These appear to be all zeros in the tract files.
+            # mcal_weight appears to be all zeros in the tract files.
             # possibly they should in fact all be ones.
             'mcal_weight': np.zeros(nobj),
             'mcal_gpsf': np.zeros(nobj),
             'mcal_Tpsf': np.repeat(psf_T, nobj),
+            'mcal_flags': np.repeat(0, nobj),
             # Everything below here is wrong
             "mcal_g_cov": np.zeros((nobj,2,2)),
             "mcal_g_cov_1p": np.zeros((nobj,2,2)),

--- a/txpipe/input_cats.py
+++ b/txpipe/input_cats.py
@@ -4,7 +4,7 @@ from descformats.tx import MetacalCatalog, HDFFile
 # could also just load /global/projecta/projectdirs/lsst/groups/CS/descqa/catalog/ANL_AlphaQ_v3.0.hdf5
 
 
-class TXDProtoDC2Mock(PipelineStage):
+class TXProtoDC2Mock(PipelineStage):
     """
     This stage simulates metacal data and metacalibrated
     photometry measurements, starting from a cosmology catalogs
@@ -14,7 +14,7 @@ class TXDProtoDC2Mock(PipelineStage):
     of the DC2 catalogs being available, but might also be handy
     for starting from a purer simulation.
     """
-    name='TXDProtoDC2Mock'
+    name='TXProtoDC2Mock'
 
     inputs = [
         ('response_model', HDFFile)

--- a/txpipe/photoz.py
+++ b/txpipe/photoz.py
@@ -1,5 +1,5 @@
 from ceci import PipelineStage
-from descformats.tx import PhotozPDFFile, MetacalCatalog, YamlFile
+from descformats.tx import PhotozPDFFile, MetacalCatalog, YamlFile, HDFFile
 
 class TXRandomPhotozPDF(PipelineStage):
     """
@@ -11,7 +11,7 @@ class TXRandomPhotozPDF(PipelineStage):
     """
     name='TXRandomPhotozPDF'
     inputs = [
-        ('shear_catalog', MetacalCatalog),
+        ('photometry_catalog', HDFFile),
     ]
     outputs = [
         ('photoz_pdfs', PhotozPDFFile),
@@ -48,9 +48,11 @@ class TXRandomPhotozPDF(PipelineStage):
         # Prepare the output HDF5 file
         output_file = self.prepare_output(nobj, config, z)
 
+        suffices = ["", "_1p", "_1m", "_2p", "_2m"]
+        bands = config.bands
         # The columns we need to calculate the photo-z.
         # Note that we need all the metacalibrated variants too.
-        cols = ['mcal_pars', 'mcal_pars_1m', 'mcal_pars_1p', 'mcal_pars_2m', 'mcal_pars_2p']
+        cols = [f'mag_{band}_lsst{suffix}' for band in bands for suffix in suffices]
 
         # Loop through chunks of the data.
         # Parallelism is handled in the iterate_input function - 
@@ -58,7 +60,7 @@ class TXRandomPhotozPDF(PipelineStage):
         # responsible for.  The HDF5 parallel output mode means they can
         # all write to the file at once too.
         chunk_rows = config['chunk_rows']
-        for start, end, data in self.iterate_fits('shear_catalog', hdu, cols, chunk_rows):
+        for start, end, data in self.iterate_hdf('photometry_catalog', "photometry", cols, chunk_rows):
             print(f"Process {self.rank} running photo-z for rows {start}-{end}")
 
             # Compute some mock photo-z PDFs and point estimates

--- a/txpipe/photoz.py
+++ b/txpipe/photoz.py
@@ -42,7 +42,7 @@ class TXRandomPhotozPDF(PipelineStage):
         # Open the input catalog and check how many objects
         # we will be running on.
         cat = self.open_input("photometry_catalog")
-        nobj = cat['photometry/galaxy_id'].size
+        nobj = cat['photometry/id'].size
         cat.close()
         
         # Prepare the output HDF5 file


### PR DESCRIPTION
This PR splits the shear catalog into shear and photometry catalogs, and provides a module that generates mock versions of both directly from protoDC2.