### PR TITLE
Add option to use input pz instead of running MLZ

### DIFF
--- a/examples/config.yml
+++ b/examples/config.yml
@@ -19,6 +19,7 @@ TXPhotozStack:
     chunk_rows: 100000
 
 TXSelector:
+    input_pz: False
     bands: riz #used for selection
     T_cut: 0.5
     s2n_cut: 10.0

--- a/txpipe/selector.py
+++ b/txpipe/selector.py
@@ -82,6 +82,7 @@ class TXSelector(PipelineStage):
         # various config options
         bands = self.config['bands']
         chunk_rows = self.config['chunk_rows']
+        #print(self.config['input_pz'])
 
         if self.config['input_pz'] == False:
             # Build a classifier used to put objects into tomographic bins

--- a/txpipe/selector.py
+++ b/txpipe/selector.py
@@ -99,6 +99,11 @@ class TXSelector(PipelineStage):
         shear_cols += metacal_variants('mcal_T', 'mcal_s2n', 'mcal_g1', 'mcal_g2')
         if self.config['input_pz'] == True:
             shear_cols += ['mean_z']
+            shear_cols += ['mean_z_1p']
+            shear_cols += ['mean_z_1m']
+            shear_cols += ['mean_z_2p']
+            shear_cols += ['mean_z_2m']
+
 
         # Input data.  These are iterators - they lazily load chunks
         # of the data one by one later when we do the for loop.
@@ -257,7 +262,7 @@ class TXSelector(PipelineStage):
         pz_data = {}
 
         for v in variants:
-            zz = shear_data['mean_z{v}']
+            zz = shear_data[f'mean_z{v}']
 
             pz_data_v = np.zeros(len(zz)) -1
             for zi in range(len(self.config['zbin_edges'])-1):


### PR DESCRIPTION
In selector.py add the option to use an input redshift point-estimate for each galaxy to do the binning. This is determined by the parameter `input_pz`  set in the configuration file. `input_pz: False` will give the original pipeline. 

- requires a pre-existing photoz_stack.hdf5 file 
- skip "PZPDFMLZ" and "TXPhotozStack" stages if `input_pz: True`

Example for DES Y1 is described [here](https://github.com/LSSTDESC/txpipe-reanalysis/issues/6). Other experiments will do this differently since they do not have metacal photo-z's. Yaml and config files [here](https://github.com/LSSTDESC/txpipe-reanalysis/blob/master/desy1/desy1_input_pz.yml) and [here](https://github.com/LSSTDESC/txpipe-reanalysis/blob/master/desy1/config_input_pz.yml). 