### PR TITLE
Updated ingestion

### DIFF
--- a/txpipe/__init__.py
+++ b/txpipe/__init__.py
@@ -12,7 +12,7 @@ from .random_cats import TXRandomCat
 from .sysmaps import TXDiagnosticMaps
 from .twopoint_fourier import TXTwoPointFourier
 from .twopoint import TXTwoPoint
-from .input_cats import TXProtoDC2Mock
+from .input_cats import TXCosmoDC2Mock
 from .photoz_mlz import PZPDFMLZ
 from .covariance import TXFourierGaussianCovariance
 from .metacal_gcr_input import TXMetacalGCRInput

--- a/txpipe/input_cats.py
+++ b/txpipe/input_cats.py
@@ -4,7 +4,7 @@ from .utils.metacal import metacal_band_variants, metacal_variants
 import numpy as np
 from .utils.timer import Timer
 
-class TXProtoDC2Mock(PipelineStage):
+class TXCosmoDC2Mock(PipelineStage):
     """
     This stage simulates metacal data and metacalibrated
     photometry measurements, starting from a cosmology catalogs
@@ -14,7 +14,7 @@ class TXProtoDC2Mock(PipelineStage):
     of the DC2 catalogs being available, but might also be handy
     for starting from a purer simulation.
     """
-    name='TXProtoDC2Mock'
+    name='TXCosmoDC2Mock'
 
     inputs = [
         ('response_model', HDFFile)
@@ -26,12 +26,14 @@ class TXProtoDC2Mock(PipelineStage):
     ]
 
     config_options = {
-        'cat_name':'protoDC2_test',
+        'cat_name':'cosmoDC2',
         'visits_per_band':165,  # used in the noise simulation
         'snr_limit':4.0,  # used to decide what objects to cut out
         'max_size': 99999999999999,  #for testing on smaller catalogs
         'extra_cols': "", # string-separated list of columns to include
         'max_npix':99999999999999,
+        'unit_response': False,
+        'flip_g2': True, # this matches the metacal definition, and the treecorr/namaster one
         }
 
     def data_iterator(self, gc):
@@ -45,6 +47,7 @@ class TXProtoDC2Mock(PipelineStage):
                 'shear_1', 'shear_2',
                 'size_true',
                 'galaxy_id',
+                'redshift_true',
                 ]
         # Add any extra requestd columns
         cols += self.config['extra_cols'].split()
@@ -68,7 +71,7 @@ class TXProtoDC2Mock(PipelineStage):
             # Load the input catalog (this is lazy)
             # For testing we may want to cut down to a smaller number of pixels.
             # This is separate from the split by processor later on
-            all_healpix_pixels = GCRCatalogs.available_catalogs[cat_name]['healpix_pixels']
+            all_healpix_pixels = GCRCatalogs.get_available_catalogs()[cat_name]['healpix_pixels']
             max_npix = self.config['max_npix']
             if max_npix != 99999999999999:
                 print(f"Cutting down initial catalog to {max_npix} healpix pixels")
@@ -149,10 +152,14 @@ class TXProtoDC2Mock(PipelineStage):
 
             # Simulate the various output data sets
             mock_photometry = self.make_mock_photometry(data)
-            mock_metacal = self.make_mock_metacal(data, mock_photometry)
 
-            # Cut out any objects too faint to be detected and measured
-            self.remove_undetected(data, mock_photometry, mock_metacal)
+            # Cut out any objects too faint to be detected and measured.
+            # We have to do this after the photometry, so that we know if
+            # the object is detected, but we can do it before making the mock
+            # metacal info, saving us some time simulating un-needed objects
+            self.remove_undetected(data, mock_photometry)
+
+            mock_metacal = self.make_mock_metacal(data, mock_photometry)
             # The chunk size has now changed
             some_col = list(mock_photometry.keys())[0]
             chunk_size = len(mock_photometry[some_col])
@@ -172,13 +179,33 @@ class TXProtoDC2Mock(PipelineStage):
             
             if start >= target_size:
                 break
-
-
-            
         # Tidy up
-        #self.truncate_output(photo_file, metacal_file, end)
+
         photo_file.close()
         metacal_file.close()
+
+        self.truncate_outputs(end)
+
+    def truncate_outputs(self, n):
+        import h5py
+        if self.comm is not None:
+            self.comm.Barrier()
+
+        if self.rank == 0:
+            # all files should now be closed for all procs
+            print(f"Resizing all outupts to size {n}")
+            f = h5py.File(self.get_output('photometry_catalog'))
+            g = f['photometry']
+            for col in list(g.keys()):
+                g[col].resize((n,))
+            f.close()
+
+            f = h5py.File(self.get_output('shear_catalog'))
+            g = f['metacal']
+            for col in g.keys():
+                g[col].resize((n,))
+
+
 
     def next_output_indices(self, start, chunk_size):
         if self.comm is None:
@@ -197,7 +224,6 @@ class TXProtoDC2Mock(PipelineStage):
 
 
     def setup_photometry_output(self, photo_file, target_size):
-        from .utils.hdf_tools import create_dataset_early_allocated
         # Get a list of all the column names
         cols = ['ra', 'dec']
         for band in self.bands:
@@ -214,18 +240,16 @@ class TXProtoDC2Mock(PipelineStage):
         # Extensible columns becase we don't know the size yet.
         # We will cut down the size at the end.
         for col in cols:
-            create_dataset_early_allocated(group, col, target_size, 'f8')
+            group.create_dataset(col, (target_size,), maxshape=(target_size,), dtype='f8')
 
         # The only non-float column for now
-        create_dataset_early_allocated(group, 'id', target_size, 'i8')
+        group.create_dataset('id', (target_size,), maxshape=(target_size,), dtype='i8')
 
         return cols + ['id']
 
 
 
     def setup_metacal_output(self, metacal_file, target_size):
-        from .utils.hdf_tools import create_dataset_early_allocated
-
         # Get a list of all the column names
         cols = (
             ['ra', 'dec', 'mcal_psf_g1', 'mcal_psf_g2', 'mcal_psf_T_mean']
@@ -243,10 +267,11 @@ class TXProtoDC2Mock(PipelineStage):
         
 
         for col in cols:
-            create_dataset_early_allocated(group, col, target_size, 'f8')
+            group.create_dataset(col, (target_size,), maxshape=(target_size,), dtype='f8')
 
-        create_dataset_early_allocated(group, 'id', target_size, 'i8')
-        create_dataset_early_allocated(group, 'mcal_flags', target_size, 'i4')
+        group.create_dataset('id', (target_size,), maxshape=(target_size,), dtype='i8')
+        group.create_dataset('mcal_flags', (target_size,), maxshape=(target_size,), dtype='i8')
+
 
         return cols + ['id',  'mcal_flags']
         
@@ -264,7 +289,10 @@ class TXProtoDC2Mock(PipelineStage):
 
         """
         import scipy.interpolate
-        import numpy as np
+
+        if self.config['unit_response']:
+            return
+
         model_file = self.open_input("response_model")
         snr_centers = model_file['R_model/log10_snr'][:]
         sz_centers = model_file['R_model/size'][:]
@@ -316,7 +344,7 @@ class TXProtoDC2Mock(PipelineStage):
         # The visit count affects the overall noise levels
         n_visit = self.config['visits_per_band']
         # Do all the work in the function below
-        photo = make_mock_photometry(n_visit, self.bands, data)
+        photo = make_mock_photometry(n_visit, self.bands, data, self.config['unit_response'])
 
         for col in self.config['extra_cols'].split():
             photo[col] = data[col]
@@ -351,11 +379,15 @@ class TXProtoDC2Mock(PipelineStage):
             photo['snr_i']**2 + 
             photo['snr_z']**2
             )**0.5
-        snr_1p = (photo['snr_r_1p']**2 + photo['snr_i_1p'] + photo['snr_z_1p'])**0.5
-        snr_1m = (photo['snr_r_1m']**2 + photo['snr_i_1m'] + photo['snr_z_1m'])**0.5
-        snr_2p = (photo['snr_r_2p']**2 + photo['snr_i_2p'] + photo['snr_z_2p'])**0.5
-        snr_2m = (photo['snr_r_2m']**2 + photo['snr_i_2m'] + photo['snr_z_2m'])**0.5
+        snr_1p = (photo['snr_r_1p']**2 + photo['snr_i_1p']**2 + photo['snr_z_1p']**2)**0.5
+        snr_1m = (photo['snr_r_1m']**2 + photo['snr_i_1m']**2 + photo['snr_z_1m']**2)**0.5
+        snr_2p = (photo['snr_r_2p']**2 + photo['snr_i_2p']**2 + photo['snr_z_2p']**2)**0.5
+        snr_2m = (photo['snr_r_2m']**2 + photo['snr_i_2m']**2 + photo['snr_z_2m']**2)**0.5
 
+        if self.config['unit_response']:
+            assert np.allclose(snr, snr_1p)
+            assert np.allclose(snr, snr_2m)
+        
         nobj = snr.size
 
         log10_snr = np.log10(snr)
@@ -374,16 +406,21 @@ class TXProtoDC2Mock(PipelineStage):
         psf_sigma = psf_fwhm/(2*np.sqrt(2*np.log(2)))
         psf_T = 2 * psf_sigma**2
 
-        # Use the response model to get a reasonable response
-        # value for this size and SNR
-        R_mean = self.R_spline(log10_snr, size_T, grid=False)
-        R_std = self.Rstd_spline(log10_snr, size_T, grid=False)
-        
-        # Assume a 0.2 correlation between the size response
-        # and the shear response.
-        rho = 0.2
-        f = np.random.multivariate_normal([0.0,0.0], [[1.0,rho],[rho,1.0]], nobj).T
-        R, R_size = f * R_std + R_mean
+        if self.config['unit_response']:
+            R = 1.0
+            R_size = 0.0
+
+        else:
+            # Use the response model to get a reasonable response
+            # value for this size and SNR
+            R_mean = self.R_spline(log10_snr, size_T, grid=False)
+            R_std = self.Rstd_spline(log10_snr, size_T, grid=False)
+            
+            # Assume a 0.2 correlation between the size response
+            # and the shear response.
+            rho = 0.2
+            f = np.random.multivariate_normal([0.0,0.0], [[1.0,rho],[rho,1.0]], nobj).T
+            R, R_size = f * R_std + R_mean
 
         # Convert magnitudes to fluxes according to the baseline
         # use in the metacal numbers
@@ -402,6 +439,10 @@ class TXProtoDC2Mock(PipelineStage):
         # True shears without shape noise
         g1 = data['shear_1']
         g2 = data['shear_2']
+
+        if self.config['flip_g2']:
+            g2 *= -1
+
         # Do the full combination of (g,epsilon) -> e, not the approx one
         g = g1 + 1j*g2
         e = (eps + g) / (1+g.conj()*eps)
@@ -507,7 +548,7 @@ class TXProtoDC2Mock(PipelineStage):
 
 
 
-    def remove_undetected(self, data, photo, metacal):
+    def remove_undetected(self, data, photo):
         """
         Strip out any undetected objects from the two
         simulated data sets.
@@ -528,8 +569,13 @@ class TXProtoDC2Mock(PipelineStage):
             not_detected_in_band = ~detected_in_band
             # Set objects not detected in one band that are detected in another
             # to inf magnitude in that band, and the SNR to zero.
-            photo[f'snr_{band}'][not_detected_in_band] = 0.0
-            photo[f'{band}_mag'][not_detected_in_band] = np.inf
+            # We have to do this for each of the variants also, because otherwise
+            # we end up with wildly different final SNR values later.
+            # This is the metadetection issue really!
+            for v in metacal_variants(f'snr_{band}'):
+                photo[v][not_detected_in_band] = 0.0
+            for v in metacal_variants(f'{band}_mag'):
+                photo[v][not_detected_in_band] = np.inf
 
             # Record that we have detected this object at all
             detected |= detected_in_band
@@ -554,27 +600,13 @@ class TXProtoDC2Mock(PipelineStage):
         for key in list(photo.keys()): 
             photo[key] = photo[key][detected]
 
-        for key in list(metacal.keys()):
-            metacal[key] = metacal[key][detected]
+        for key in list(data.keys()):
+            data[key] = data[key][detected]
 
 
-    def truncate_output(self, photo_file, metacal_file, end):
-        """
-        Cut down the output photometry file to its final 
-        size.
-        """
-        group = photo_file['photometry']
-        cols = list(group.keys())
-        for col in cols:
-            group[col].resize((end,))
-
-        group = metacal_file['metacal']
-        cols = list(group.keys())
-        for col in cols:
-            group[col].resize((end,))
 
 
-def make_mock_photometry(n_visit, bands, data):
+def make_mock_photometry(n_visit, bands, data, unit_response):
     """
     Generate a mock photometric table with noise added
 
@@ -616,7 +648,10 @@ def make_mock_photometry(n_visit, bands, data):
     factor = 5455./gain * (D/6.5)**2 * (time/30.)
 
     # Fake some metacal responses
-    mag_responses = generate_mock_metacal_mag_responses(bands, nobj)
+    if unit_response:
+        mag_responses = [0.0 for i in bands]
+    else:
+        mag_responses = generate_mock_metacal_mag_responses(bands, nobj)
 
     delta_gamma = 0.01  # this is the half-delta gamma, i.e. gamma_+ - gamma_0
     # that's the right thing to use here because we are doing m+ = m0 + dm/dy*dy
@@ -688,6 +723,7 @@ def make_mock_photometry(n_visit, bands, data):
 
 
 def generate_mock_metacal_mag_responses(bands, nobj):
+    print("WARNING: getting oddly large S/N variation from mock metacal mags")
     nband = len(bands)
     mu = np.zeros(nband) # seems approx mean of response across bands, from HSC tract
     rho = 0.25  #  approx correlation between response in bands, from HSC tract
@@ -697,164 +733,6 @@ def generate_mock_metacal_mag_responses(bands, nobj):
     mag_responses = np.random.multivariate_normal(mu, covmat, nobj).T
     return mag_responses
 
-
-class TXGCRMockMetacal(PipelineStage):
-    """
-    Use real photometry from the DRP (output of DM stack) in merged form,
-    but fake metacal responses for the magnitudes.
-
-    TODO: Shapes!
-    """
-    name = "TXGCRMockMetacal"
-
-    inputs = [
-        ('response_model', HDFFile),
-    ]
-
-    outputs = [
-        ('photometry_catalog', HDFFile),
-    ]
-
-    config_options = {
-        'cat_name':'dc2_coadd_run1.1p',
-        'snr_limit':4.0,  # used to decide what objects to cut out
-        'max_size': 99999999999999  #for testing on smaller catalogs
-        }
-
-    def count_rows(self, cat_name):
-        counts = {
-            'dc2_coadd_run1.1p':6892380,
-        }
-        n = counts.get(cat_name)
-        if n is None:
-            raise ValueError("Sorry - there is no way to count the number of rows in a GCR catalog yet, so we have to hard-code them.  And your catalog we don't know.")
-        return n
-
-    def run(self):
-        # import everything early so we are told asap if anything
-        # is missing
-        import GCRCatalogs
-        from .utils import hdf_tools
-        import scipy.interpolate
-
-        cat_name = self.config['cat_name']
-        self.bands = 'ugrizy'
-
-        self.load_metacal_response_model()
-
-        # Load the input catalog (this is lazy)
-        gc = GCRCatalogs.load_catalog(cat_name, {'md5': None})
-
-
-        n = self.count_rows(cat_name)
-        print(f"Found {n} objects in catalog {cat_name}")
-
-
-        # Put everything under the "photometry" section
-        output_photo = self.open_output('photometry_catalog')
-        photo = output_photo.create_group('photometry')
-
-        # The merged DRP file is already split into chunks internally - we load those 
-        # chunks one by one
-        for (start, end, data) in self.generate_fake_metacalibrated_photometry(gc):
-
-            # For the first chunk we create the output data space, 
-            # because then we know what all the columns are
-            if start==0:
-                for colname,col in data.items():
-                    photo.create_dataset(colname, (n,), dtype=col.dtype)
-                    print(f" Column: {colname}")
-
-            # Output this chunk
-            print(f" Saving rows {start}:{end}")
-            for colname,col in data.items():
-                photo[colname][start:end] = col
-
-        output_photo.close()
-
-
-    def generate_fake_metacalibrated_photometry(self, gc):
-        import h5py
-        import pandas
-        import warnings
-
-
-        mag_names = [f'mag_{b}' for b in self.bands]
-        err_names = [f'{b}_mag_err' for b in self.bands]
-        snr_names = [f'snr_{b}_cModel' for b in self.bands]
-        # Columns we need from the cosmo simulation
-        cols = mag_names + err_names + snr_names
-        start = 0
-        delta_gamma = 0.01
-
-        for data in gc.get_quantities(cols, return_iterator=True):
-            n = len(data[mag_names[0]])
-            end = start + n
-
-            # Fake magnitude responses
-            mag_responses = generate_mock_metacal_mag_responses(self.bands, n)
-
-            output = {}
-            for band, mag_resp in zip(self.bands, mag_responses):
-                # Mags and SNR are in the catalog already
-                mag_obs = data[f'{band}_mag']
-                snr     = data[f'snr_{band}_cModel']
-                mag_err = data[f'{band}_mag_err']
-
-                output[f'{band}_mag']    = mag_obs
-                output[f'{band}_mag_err'] = mag_err
-                output[f'snr_{band}']    = snr
-
-                # Generate the metacalibrated values
-                mag_obs_1p = mag_obs + mag_resp*delta_gamma
-                mag_obs_1m = mag_obs - mag_resp*delta_gamma
-                mag_obs_2p = mag_obs + mag_resp*delta_gamma
-                mag_obs_2m = mag_obs - mag_resp*delta_gamma
-
-                # Save them, but we will also need them to generate
-                # metacalibrated SNRs below
-                output[f'{band}_mag_1p'] = mag_obs_1p
-                output[f'{band}_mag_1m'] = mag_obs_1m
-                output[f'{band}_mag_2p'] = mag_obs_2p
-                output[f'{band}_mag_2m'] = mag_obs_2m
-
-                # Scale the SNR values according the to change in magnitude.
-                output[f'snr_{band}_1p'] = snr * 10**(0.4*(mag_obs - mag_obs_1p))
-                output[f'snr_{band}_1m'] = snr * 10**(0.4*(mag_obs - mag_obs_1m))
-                output[f'snr_{band}_2p'] = snr * 10**(0.4*(mag_obs - mag_obs_2p))
-                output[f'snr_{band}_2m'] = snr * 10**(0.4*(mag_obs - mag_obs_2m))
-
-            yield start, end, output
-            start = end
-
-
-
-
-
-    def load_metacal_response_model(self):
-        """
-        Load an HDF file containing the response model
-        R(log10(snr), size)
-        R_std(log10(snr), size)
-
-        where R is the mean metacal response in a bin and
-        R_std is its standard deviation.
-
-        So far only one of these files exists!
-
-        """
-        import scipy.interpolate
-        model_file = self.open_input("response_model")
-        snr_centers = model_file['R_model/log10_snr'][:]
-        sz_centers = model_file['R_model/size'][:]
-        R_mean = model_file['R_model/R_mean'][:]
-        R_std = model_file['R_model/R_std'][:]
-        model_file.close()
-
-        # Save a 2D spline
-        snr_grid, sz_grid = np.meshgrid(snr_centers, sz_centers)
-        self.R_spline=scipy.interpolate.SmoothBivariateSpline(snr_grid.T.flatten(), sz_grid.T.flatten(), R_mean.flatten(), w=R_std.flatten())
-        self.Rstd_spline=scipy.interpolate.SmoothBivariateSpline(snr_grid.T.flatten(), sz_grid.T.flatten(), R_std.flatten())        
 
 
 
@@ -870,6 +748,6 @@ def test():
     M5 = [24.22, 25.17, 24.74, 24.38, 23.80]
     for b,m5 in zip(bands, M5):
         data[f'mag_true_{b}_lsst'] = np.repeat(m5, 10000)
-    results = make_mock_photometry(n_visit, bands, data)
+    results = make_mock_photometry(n_visit, bands, data, True)
     pylab.hist(results['snr_r'], bins=50, histtype='step')
     pylab.savefig('snr_r.png')


### PR DESCRIPTION
- Renames to CosmoDC2Mock and uses that catalog (instead of Proto) by default
- Updates GCR calls
- Add unit_response option to make all metacal R values either 1 (for shear R11 and R22) or 0 (everything else) 
- Adds flip_g2 option to make convention match treecorr and NaMaster
- Speed up
- Fix bug giving wrong SNR values for variants, affecting selection corrections
- Remove old code