### PR TITLE
Fixes to work in Fourier space with 2.1i data

### DIFF
--- a/txpipe/base_stage.py
+++ b/txpipe/base_stage.py
@@ -20,8 +20,9 @@ class PipelineStage(PipelineStageBase):
             provenance[f"config/{key}"] = str(value)
 
         for name, tag_cls in self.inputs:
+            f = self.open_input(name, wrapper=True)
             try:
-                f = self.open_input(name, wrapper=True)
+                #f = self.open_input(name, wrapper=True)
                 input_id = f.provenance['uuid']
                 provenance[f"input/{name}"] = input_id
             except (OSError, IOError, KeyError):

--- a/txpipe/mapping/basic_maps.py
+++ b/txpipe/mapping/basic_maps.py
@@ -172,7 +172,7 @@ class FlagMapper:
         pix_nums = self.pixel_scheme.ang2pix(ra, dec)
         for i, m in enumerate(self.maps):
             f = 2**i
-            w = np.where(f & flags > 0)
+            w = np.where(f & (flags > 0))
             for p in pix_nums[w]:
                 m[p] += 1
 


### PR DESCRIPTION
This PR contains several small fixes to be able to run the `TXTwoPointFourier` stage in 2.1i data