### PR TITLE
Generate a new lens_weight column on ingest/select.  Not yet used

### DIFF
--- a/txpipe/ingest_redmagic.py
+++ b/txpipe/ingest_redmagic.py
@@ -58,6 +58,7 @@ class TXIngestRedmagic(PipelineStage):
 
         h = tomo.create_group('tomography')
         h.create_dataset('lens_bin', (n,), dtype=np.int32)
+        h.create_dataset('lens_weight', (n,), dtype=np.float64)
         h.create_dataset('lens_counts', (nbin_lens,), dtype='i')
         h.attrs['nbin_lens'] = nbin_lens
         h.attrs[f'lens_zbin_edges'] = zbin_edges
@@ -107,6 +108,7 @@ class TXIngestRedmagic(PipelineStage):
                 g[f'mag_err_{b}'][s:e] = data['mag_err'][:, i]
 
             h['lens_bin'][s:e] = zbin
+            h['lens_weight'][s:e] = 1.0
 
         # this is an overall count
         h["lens_counts"][:] = counts

--- a/txpipe/lens_selector.py
+++ b/txpipe/lens_selector.py
@@ -135,6 +135,7 @@ class TXBaseLensSelector(PipelineStage):
         outfile = self.open_output('lens_tomography_catalog', parallel=True)
         group = outfile.create_group('tomography')
         group.create_dataset('lens_bin', (n,), dtype='i')
+        group.create_dataset('lens_weight', (n,), dtype='f')
         group.create_dataset('lens_counts', (nbin_lens,), dtype='i')
 
         group.attrs['nbin_lens'] = nbin_lens
@@ -165,6 +166,7 @@ class TXBaseLensSelector(PipelineStage):
 
         group = outfile['tomography']
         group['lens_bin'][start:end] = lens_bin
+        group['lens_weight'][start:end] = 1.0
 
     def write_global_values(self, outfile, number_density_stats):
         """


### PR DESCRIPTION
This is to support later use of lens weights.  Currently these are not used, but in a subsequent PR they will be.