### PR TITLE
Adds support for buzzard as input mock catalog

### DIFF
--- a/examples/buzzard_input_pipeline.yml
+++ b/examples/buzzard_input_pipeline.yml
@@ -10,9 +10,9 @@ modules: txpipe
 
 stages:
     - name: TXBuzzardMock
-      nprocess: 1
+      nprocess: 4
 
-output_dir: /global/projecta/projectdirs/lsst/groups/WL/users/flanusse/buzzard-inputs
+output_dir: /global/projecta/projectdirs/lsst/groups/WL/users/flanusse/buzzard-inputs_6
 config: examples/config/buzzard_config.yml
 
 # On NERSC, set this before running:

--- a/examples/buzzard_input_pipeline.yml
+++ b/examples/buzzard_input_pipeline.yml
@@ -1,0 +1,28 @@
+launcher:
+    name: mini
+    interval: 3.0
+
+site:
+    name: cori-interactive
+    image: joezuntz/txpipe
+
+modules: txpipe
+
+stages:
+    - name: TXBuzzardMock
+      nprocess: 1
+
+output_dir: /global/projecta/projectdirs/lsst/groups/WL/users/flanusse/buzzard-inputs
+config: examples/config/buzzard_config.yml
+
+# On NERSC, set this before running:
+# export DATA=${LSST}/groups/WL/users/zuntz/data/metacal-testbed
+
+inputs:
+    # See README for paths to download these files
+    response_model: /global/projecta/projectdirs/lsst/groups/WL/users/zuntz/data/DESY1-R-model.hdf5
+
+resume: True
+log_dir: data/buzzard/logs
+pipeline_log: data/buzzard/log.txt
+

--- a/examples/config/buzzard_config.yml
+++ b/examples/config/buzzard_config.yml
@@ -1,0 +1,6 @@
+TXBuzzardMock:
+    cat_name: buzzard
+    visits_per_band: 16
+    extra_cols: redshift_true size_true shear_1 shear_2
+    flip_g2: True # to match metacal
+    max_npix: 1

--- a/examples/config/buzzard_config.yml
+++ b/examples/config/buzzard_config.yml
@@ -3,4 +3,4 @@ TXBuzzardMock:
     visits_per_band: 16
     extra_cols: redshift_true size_true shear_1 shear_2
     flip_g2: True # to match metacal
-    max_npix: 1
+    max_npix: 4


### PR DESCRIPTION
This small PR simply adds the option to create some mock metacal input data out of Buzzard

NOTE: That I couldn't excatly manage to run it for more than one healpix pixel, I'm not sure how @joezuntz does it for CosmoDC2. 

Also I've had to comment out this line:
https://github.com/LSSTDESC/TXPipe/blob/1023b100176205c01ae41e9acb7fcfd9c4883d18/txpipe/input_cats.py#L342
It was failing and I couldn't understand why it was there....