### PR TITLE
No shape noise

### DIFF
--- a/examples/config/cosmodc2_config.yml
+++ b/examples/config/cosmodc2_config.yml
@@ -114,7 +114,7 @@ TXTwoPoint:
     max_sep: 250
     nbins: 20
     verbose: 0
-    use_true_shear: True
+    use_true_shear: False
 
 TXTwoPointLensCat:
     binslop: 0.0
@@ -127,7 +127,7 @@ TXTwoPointLensCat:
     max_sep: 250
     nbins: 20
     verbose: 0
-    use_true_shear: True
+    use_true_shear: False
     
 TXTwoPointFourier:
     chunk_rows: 100000
@@ -138,7 +138,7 @@ TXTwoPointFourier:
     cache_dir: ./cache
     
 TXRealGaussianCovariance:
-    use_true_shear: True
+    use_true_shear: False
 
 TXClusteringNoiseMaps:
     n_realization: 30

--- a/examples/config/cosmodc2_config.yml
+++ b/examples/config/cosmodc2_config.yml
@@ -136,7 +136,9 @@ TXTwoPointFourier:
     bandwidth: 200
     apodization_size: 0.0
     cache_dir: ./cache
-
+    
+TXRealGaussianCovariance:
+    use_true_shear: True
 
 TXClusteringNoiseMaps:
     n_realization: 30

--- a/txpipe/covariance.py
+++ b/txpipe/covariance.py
@@ -13,7 +13,7 @@ d2r=np.pi/180
 class TXFourierGaussianCovariance(PipelineStage):
     name='TXFourierGaussianCovariance'
     do_xi=False
-
+    
     inputs = [
         ('fiducial_cosmology', YamlFile),    # For the cosmological parameters
         ('twopoint_data_fourier', SACCFile), # For the binning information
@@ -26,6 +26,8 @@ class TXFourierGaussianCovariance(PipelineStage):
 
     config_options = {
         'pickled_wigner_transform': '',
+        'use_true_shear': False,
+        
     }
 
 
@@ -102,7 +104,11 @@ class TXFourierGaussianCovariance(PipelineStage):
         # per-bin quantities
         N_eff = input_data['tracers/N_eff'][:]
         N_lens = input_data['tracers/lens_counts'][:]
-        sigma_e = input_data['tracers/sigma_e'][:]
+        if self.config['use_true_shear']:
+            nbins = len(input_data['tracers/sigma_e'][:])
+            sigma_e = np.array([0. for i in range(nbins)])
+        else:
+            sigma_e = input_data['tracers/sigma_e'][:]
 
         # area in sq deg
         area_deg2 = input_data['tracers'].attrs['area']


### PR DESCRIPTION
Adding an option in the Covariance stage to set sigma_e to zero when running without shape noise, to get a consistent gaussian covariance.