### PR TITLE
modify metadata to copy R_mean instead of R

### DIFF
--- a/txpipe/metadata.py
+++ b/txpipe/metadata.py
@@ -51,7 +51,7 @@ class TXTracerMetadata(PipelineStage):
             copy(shear_tomo_file, "metacal_response", "tracers", "R_S")
             copy(shear_tomo_file, "metacal_response", "tracers", "R_total")
         else:
-            copy(shear_tomo_file, "response", "tracers", "R")
+            copy(shear_tomo_file, "response", "tracers", "R_mean")
             copy(shear_tomo_file, "response", "tracers", "K")
             copy(shear_tomo_file, "response", "tracers", "C")
 
@@ -107,7 +107,7 @@ class TXTracerMetadata(PipelineStage):
                 shear_tomo_file["metacal_response/R_total"][:].tolist(),
             )
         else:
-            metadata["R"] = (shear_tomo_file["response/R"][:].tolist(),)
+            metadata["R_mean"] = (shear_tomo_file["response/R_mean"][:].tolist(),)
             metadata["K"] = (shear_tomo_file["response/K"][:].tolist(),)
             metadata["C"] = (shear_tomo_file["response/C"][:].tolist(),)
 


### PR DESCRIPTION
This saves R_scalar (which is per-bin) instead of R (which is per object) to the metadata files.

I think R_scalar should be all that's needed.

