### PR TITLE
Add 2D (non-tomographic) lens and calibrated source bins

### DIFF
--- a/txpipe/ingest_redmagic.py
+++ b/txpipe/ingest_redmagic.py
@@ -60,11 +60,13 @@ class TXIngestRedmagic(PipelineStage):
         h.create_dataset('lens_bin', (n,), dtype=np.int32)
         h.create_dataset('lens_weight', (n,), dtype=np.float64)
         h.create_dataset('lens_counts', (nbin_lens,), dtype='i')
+        h.create_dataset('lens_counts_2d', (1,), dtype='i')
         h.attrs['nbin_lens'] = nbin_lens
         h.attrs[f'lens_zbin_edges'] = zbin_edges
 
         # we keep track of the counts per-bin also
         counts = np.zeros(nbin_lens, dtype=np.int64)
+        counts_2d = 0
 
         # all cols that might be useful
         cols = ['ra', 'dec', 'zredmagic', 'mag', 'mag_err', 'chisq']
@@ -95,6 +97,7 @@ class TXIngestRedmagic(PipelineStage):
             # Build up the counts
             any_bin = zbin >= 0
             counts += np.bincount(zbin[any_bin], minlength=nbin_lens)
+            counts_2d += any_bin.sum()
 
             # save data
             g['ra'][s:e] = data['ra']
@@ -112,6 +115,7 @@ class TXIngestRedmagic(PipelineStage):
 
         # this is an overall count
         h["lens_counts"][:] = counts
+        h["lens_counts_2d"][:] = counts_2d
 
         # Finally save the n(z) values we have built up
         stack = self.open_output('lens_photoz_stack')

--- a/txpipe/lens_selector.py
+++ b/txpipe/lens_selector.py
@@ -137,6 +137,7 @@ class TXBaseLensSelector(PipelineStage):
         group.create_dataset('lens_bin', (n,), dtype='i')
         group.create_dataset('lens_weight', (n,), dtype='f')
         group.create_dataset('lens_counts', (nbin_lens,), dtype='i')
+        group.create_dataset('lens_counts_2d', (1,), dtype='i')
 
         group.attrs['nbin_lens'] = nbin_lens
         group.attrs[f'lens_zbin_edges'] = self.config['lens_zbin_edges']
@@ -176,12 +177,13 @@ class TXBaseLensSelector(PipelineStage):
         ----------
         outfile: h5py.File
         """
-        lens_counts = number_density_stats.collect()
+        lens_counts, lens_counts_2d = number_density_stats.collect()
 
 
         if self.rank==0:
             group = outfile['tomography']
             group['lens_counts'][:] = lens_counts
+            group['lens_counts_2d'][:] = lens_counts_2d
 
 
     def select_lens(self, phot_data):

--- a/txpipe/mapping/basic_maps.py
+++ b/txpipe/mapping/basic_maps.py
@@ -6,8 +6,8 @@ import numpy as np
 class Mapper:
     def __init__(self, pixel_scheme, lens_bins, source_bins, do_g=True, do_lens=True, sparse=False):
         self.pixel_scheme = pixel_scheme
-        self.source_bins = source_bins
-        self.lens_bins = lens_bins
+        self.source_bins = source_bins + ['2D']
+        self.lens_bins = lens_bins + ['2D']
         self.do_g = do_g if len(source_bins) else False
         self.do_lens = do_lens if len(lens_bins) else False
         self.sparse = sparse
@@ -22,6 +22,8 @@ class Mapper:
             t = 0
             self.stats[(b,t)] = ParallelSum(self.pixel_scheme.npix)
 
+        # We make maps of each bin independently, and also of the
+        # combined 2D case, for all selected objects.
         for b in self.source_bins:
             # For the lensing we are interested in both the mean and
             # the variance of the g1 and g2 signals in each pixel, in
@@ -62,6 +64,7 @@ class Mapper:
                 if lens_bin >= 0:
                     lw = lens_weights[i]
                     self.stats[(lens_bin, 0)].add_datum(p, lw)
+                    self.stats[('2D', 0)].add_datum(p, lw)
 
             if do_g:
                 # accumulate weighted g1, g2
@@ -72,6 +75,10 @@ class Mapper:
                     self.stats[(source_bin, 1)].add_datum(p, g1[i], sw)
                     self.stats[(source_bin, 2)].add_datum(p, g2[i], sw)
                     self.stats[(source_bin,'weight')].add_datum(p, sw)
+                    # Also save 2D case
+                    self.stats[("2D", 1)].add_datum(p, g1[i], sw)
+                    self.stats[("2D", 2)].add_datum(p, g2[i], sw)
+                    self.stats[("2D",'weight')].add_datum(p, sw)
 
 
     def finalize(self, comm=None):

--- a/txpipe/maps.py
+++ b/txpipe/maps.py
@@ -172,14 +172,14 @@ class TXSourceMaps(TXBaseMaps):
                 cal = {i:R[i] for i in range(nbin_source)}
                 cal['2D'] = f['/metacal_response/R_total_2d'][:]
             elif shear_catalog_type == "lensfit":
-                R = f['/metacal_response/R_mean'][:]
-                K = f['/metacal_response/K'][:]
-                c = f['/metacal_response/C'][:]
+                R = f['/response/R_mean'][:]
+                K = f['/response/K'][:]
+                c = f['/response/C'][:]
                 cal = {i: (R[i], K[i], c[i]) for i in range(nbin_source)}
                 cal['2D'] = (
-                    f['/metacal_response/R_mean_2d'][0],
-                    f['/metacal_response/K_2d'][0],
-                    f['/metacal_response/C_2d'][:],
+                    f['/response/R_mean_2d'][0],
+                    f['/response/K_2d'][0],
+                    f['/response/C_2d'][:],
                 )
             else:
                 raise ValueError("Unknown calibration")
@@ -279,7 +279,7 @@ class TXSourceMaps(TXBaseMaps):
                 out = self.calibrate_map_metacal(g1[i], g2[i], var_g1[i], var_g2[i], cal[i])
             elif self.config['shear_catalog_type'] == 'lensfit':
                 R, K, c = cal[i]
-                out = self.calibrate_map_lensfit(g1[i], g2[i], var_g1[i], var_g2[i], R[i], K[i], c[i])
+                out = self.calibrate_map_lensfit(g1[i], g2[i], var_g1[i], var_g2[i], R, K, c)
             else:
                 raise ValueError("Unknown calibration")
 

--- a/txpipe/maps.py
+++ b/txpipe/maps.py
@@ -145,27 +145,11 @@ class TXSourceMaps(TXBaseMaps):
     config_options = {"true_shear": False, **map_config_options}
 
     def prepare_mappers(self, pixel_scheme):
-        # read shear cols and
-        shear_catalog_type = read_shear_catalog_type(self)
-        # open and return a single mapper
-        # read nbin_source
-        with self.open_input("shear_tomography_catalog") as f:
-            nbin_source = f["tomography"].attrs["nbin_source"]
-
-            if shear_catalog_type == "metacal":
-                R = f['/metacal_response/R_total'][:] # nbin x 2 x 2
-                cal = [R]
-            elif shear_catalog_type == "lensfit":
-                R = f['/metacal_response/R_mean'][:]
-                K = f['/metacal_response/K'][:]
-                c = f['/metacal_response/C'][:]
-                cal = (R, K, c)
-            else:
-                raise ValueError("Unknown calibration")
+        # read shear cols and calibration info
+        nbin_source, cal = self.get_calibrators()
 
         # store in config so it is saved later
         self.config["nbin_source"] = nbin_source
-
         # create basic mapper object
         source_bins = list(range(nbin_source))
         lens_bins = []
@@ -177,6 +161,29 @@ class TXSourceMaps(TXBaseMaps):
             sparse=self.config["sparse"],
         )
         return [mapper, cal]
+
+    def get_calibrators(self):
+        shear_catalog_type = read_shear_catalog_type(self)
+        with self.open_input("shear_tomography_catalog") as f:
+            nbin_source = f["tomography"].attrs["nbin_source"]
+
+            if shear_catalog_type == "metacal":
+                R = f['/metacal_response/R_total'][:] # nbin x 2 x 2
+                cal = {i:R[i] for i in range(nbin_source)}
+                cal['2D'] = f['/metacal_response/R_total_2d'][:]
+            elif shear_catalog_type == "lensfit":
+                R = f['/metacal_response/R_mean'][:]
+                K = f['/metacal_response/K'][:]
+                c = f['/metacal_response/C'][:]
+                cal = {i: (R[i], K[i], c[i]) for i in range(nbin_source)}
+                cal['2D'] = (
+                    f['/metacal_response/R_mean_2d'][0],
+                    f['/metacal_response/K_2d'][0],
+                    f['/metacal_response/C_2d'][:],
+                )
+            else:
+                raise ValueError("Unknown calibration")
+        return nbin_source, cal
 
     def data_iterator(self):
 
@@ -253,14 +260,13 @@ class TXSourceMaps(TXBaseMaps):
         import healpy
 
         # We will return lists of calibrated maps
-        g1_out = []
-        g2_out = []
-        var_g1_out = []
-        var_g2_out = []
+        g1_out = {}
+        g2_out = {}
+        var_g1_out = {}
+        var_g2_out = {}
 
-        n = len(g1)
-
-        for i in range(n):
+        # We calibrate the 2D case separately
+        for i in g1.keys():
             # we want to avoid accidentally calibrating any pixels
             # that should be masked.
             mask = (
@@ -270,10 +276,9 @@ class TXSourceMaps(TXBaseMaps):
                 | (var_g2[i] == healpy.UNSEEN)
             )
             if self.config['shear_catalog_type'] == 'metacal':
-                R = cal[0]
-                out = self.calibrate_map_metacal(g1[i], g2[i], var_g1[i], var_g2[i], R[i])
+                out = self.calibrate_map_metacal(g1[i], g2[i], var_g1[i], var_g2[i], cal[i])
             elif self.config['shear_catalog_type'] == 'lensfit':
-                R, K, c = cal
+                R, K, c = cal[i]
                 out = self.calibrate_map_lensfit(g1[i], g2[i], var_g1[i], var_g2[i], R[i], K[i], c[i])
             else:
                 raise ValueError("Unknown calibration")
@@ -283,10 +288,10 @@ class TXSourceMaps(TXBaseMaps):
                 x[mask] = healpy.UNSEEN
 
             # append our results for this tomographic bin
-            g1_out.append(out[0])
-            g2_out.append(out[1])
-            var_g1_out.append(out[2])
-            var_g2_out.append(out[3])
+            g1_out[i] = out[0]
+            g2_out[i] = out[1]
+            var_g1_out[i] = out[2]
+            var_g2_out[i] = out[3]
 
         return g1_out, g2_out, var_g1_out, var_g2_out
 
@@ -486,21 +491,7 @@ class TXMainMaps(TXSourceMaps, TXLensMaps):
         )
 
     def prepare_mappers(self, pixel_scheme):
-
-        shear_catalog_type = read_shear_catalog_type(self)
-        # read both nbin values and the calibration values
-        with self.open_input("shear_tomography_catalog") as f:
-            nbin_source = f["tomography"].attrs["nbin_source"]
-            if shear_catalog_type == "metacal":
-                R = f['/metacal_response/R_total'][:] # nbin x 2 x 2
-                cal = [R]
-            elif shear_catalog_type == "lensfit":
-                R = f['response/R_mean'][:]
-                K = f['response/K'][:]
-                c = f['response/C'][:]
-                cal = (R, K, c)
-            else:
-                raise ValueError("Unknown calibration")
+        nbin_source, cal = self.get_calibrators()
 
         with self.open_input("lens_tomography_catalog") as f:
             nbin_lens = f["tomography"].attrs["nbin_lens"]

--- a/txpipe/metadata.py
+++ b/txpipe/metadata.py
@@ -139,4 +139,4 @@ class TXTracerMetadata(PipelineStage):
         area_sq_deg = pixel_scheme.pixel_area(degrees=True) * num_hit
         f_sky = float(area_sq_deg) / 41252.96125
         print(f"Area = {area_sq_deg:.2f} deg^2")
-        return area_sq_deg
+        return float(area_sq_deg)

--- a/txpipe/metadata.py
+++ b/txpipe/metadata.py
@@ -37,23 +37,38 @@ class TXTracerMetadata(PipelineStage):
         lens_tomo_file = self.open_input("lens_tomography_catalog")
 
         meta_file = self.open_output("tracer_metadata")
+        metadata = {}
 
         def copy(tomo, in_section, out_section, name):
             x = tomo[f"{in_section}/{name}"][:]
             meta_file.create_dataset(f"{out_section}/{name}", data=x)
+            metadata[name] = x.tolist()
 
         def copy_attrs(tomo, name, out_name):
             for k, v in tomo[name].attrs.items():
                 meta_file[out_name].attrs[k] = v
+                if isinstance(v, np.ndarray):
+                    v = v.tolist()
+                elif isinstance(v, np.float64):
+                    v = float(v)
+                elif isinstance(v, np.int64):
+                    v = int(v)
+                metadata[k] = v
 
         if shear_catalog_type == "metacal":
             copy(shear_tomo_file, "metacal_response", "tracers", "R_gamma_mean")
             copy(shear_tomo_file, "metacal_response", "tracers", "R_S")
             copy(shear_tomo_file, "metacal_response", "tracers", "R_total")
+            copy(shear_tomo_file, "metacal_response", "tracers", "R_gamma_mean_2d")
+            copy(shear_tomo_file, "metacal_response", "tracers", "R_S_2d")
+            copy(shear_tomo_file, "metacal_response", "tracers", "R_total_2d")
         else:
             copy(shear_tomo_file, "response", "tracers", "R_mean")
             copy(shear_tomo_file, "response", "tracers", "K")
             copy(shear_tomo_file, "response", "tracers", "C")
+            copy(shear_tomo_file, "response", "tracers", "R_mean_2d")
+            copy(shear_tomo_file, "response", "tracers", "K_2d")
+            copy(shear_tomo_file, "response", "tracers", "C_2d")
 
         copy(shear_tomo_file, "tomography", "tracers", "N_eff")
         copy(lens_tomo_file, "tomography", "tracers", "lens_counts")
@@ -62,54 +77,51 @@ class TXTracerMetadata(PipelineStage):
         copy(shear_tomo_file, "tomography", "tracers", "mean_e2")
         copy(shear_tomo_file, "tomography", "tracers", "source_counts")
 
+        copy(shear_tomo_file, "tomography", "tracers", "N_eff_2d")
+        copy(lens_tomo_file, "tomography", "tracers", "lens_counts_2d")
+        copy(shear_tomo_file, "tomography", "tracers", "sigma_e_2d")
+        copy(shear_tomo_file, "tomography", "tracers", "mean_e1_2d")
+        copy(shear_tomo_file, "tomography", "tracers", "mean_e2_2d")
+        copy(shear_tomo_file, "tomography", "tracers", "source_counts_2d")
+
         N_eff = shear_tomo_file["tomography/N_eff"][:]
+        N_eff_2d = shear_tomo_file["tomography/N_eff_2d"][:]
         n_eff = N_eff / area_sq_arcmin
+        n_eff_2d = N_eff_2d / area_sq_arcmin
 
         lens_counts = lens_tomo_file["tomography/lens_counts"][:]
         source_counts = shear_tomo_file["tomography/source_counts"][:]
+        lens_counts_2d = lens_tomo_file["tomography/lens_counts_2d"][:]
+        source_counts_2d = shear_tomo_file["tomography/source_counts_2d"][:]
 
         lens_density = lens_counts / area_sq_arcmin
         source_density = source_counts / area_sq_arcmin
+        lens_density_2d = lens_counts_2d / area_sq_arcmin
+        source_density_2d = source_counts_2d / area_sq_arcmin
 
         meta_file.create_dataset("tracers/n_eff", data=n_eff)
         meta_file.create_dataset("tracers/lens_density", data=lens_density)
         meta_file.create_dataset("tracers/source_density", data=source_density)
+        meta_file.create_dataset("tracers/lens_density_2d", data=lens_density_2d)
+        meta_file.create_dataset("tracers/source_density_2d", data=source_density_2d)
         meta_file["tracers"].attrs["area"] = area
         meta_file["tracers"].attrs["area_unit"] = "deg^2"
         meta_file["tracers"].attrs["density_unit"] = "arcmin^{-2}"
+        metadata['n_eff'] = n_eff.tolist()
+        metadata['n_eff_2d'] = n_eff_2d.tolist()
+        metadata['lens_density'] = lens_density.tolist()
+        metadata['source_density'] = source_density.tolist()
+        metadata['lens_density_2d'] = lens_density_2d.tolist()
+        metadata['source_density_2d'] = source_density_2d.tolist()
+        metadata['area'] = area
+        metadata['area_unit'] = "deg^2"
+        metadata['density_unit'] = "arcmin^{-2}"
         copy_attrs(shear_tomo_file, "tomography", "tracers")
         copy_attrs(lens_tomo_file, "tomography", "tracers")
-
         meta_file.close()
 
         # human readable version
         yaml_out_name = self.get_output("tracer_metadata_yml")
-        metadata = {
-            "lens_density": lens_density.tolist(),
-            "source_density": source_density.tolist(),
-            "sigma_e": shear_tomo_file["tomography/sigma_e"][:].tolist(),
-            "mean_e1": shear_tomo_file["tomography/mean_e1"][:].tolist(),
-            "mean_e2": shear_tomo_file["tomography/mean_e2"][:].tolist(),
-            "n_eff": n_eff.tolist(),
-            "lens_counts": lens_counts.tolist(),
-            "source_counts": source_counts.tolist(),
-            "area": float(area),
-            "area_unit": "deg^2",
-            "density_unit": "arcmin^{-2}",
-        }
-
-        if shear_catalog_type == "metacal":
-            metadata["R_gamma_mean"] = (
-                shear_tomo_file["metacal_response/R_gamma_mean"][:].tolist(),
-            )
-            metadata["R_S"] = (shear_tomo_file["metacal_response/R_S"][:].tolist(),)
-            metadata["R_total"] = (
-                shear_tomo_file["metacal_response/R_total"][:].tolist(),
-            )
-        else:
-            metadata["R_mean"] = (shear_tomo_file["response/R_mean"][:].tolist(),)
-            metadata["K"] = (shear_tomo_file["response/K"][:].tolist(),)
-            metadata["C"] = (shear_tomo_file["response/C"][:].tolist(),)
 
         f = open(yaml_out_name, "w")
         yaml.dump(metadata, f)
@@ -125,6 +137,6 @@ class TXTracerMetadata(PipelineStage):
 
         num_hit = (m > 0).sum()
         area_sq_deg = pixel_scheme.pixel_area(degrees=True) * num_hit
-        f_sky = area_sq_deg / 41252.96125
+        f_sky = float(area_sq_deg) / 41252.96125
         print(f"Area = {area_sq_deg:.2f} deg^2")
         return area_sq_deg

--- a/txpipe/source_selector.py
+++ b/txpipe/source_selector.py
@@ -133,8 +133,11 @@ class TXSourceSelector(PipelineStage):
 
         if shear_catalog_type == 'metacal':
             calibrators = [ParallelCalibratorMetacal(self.select, delta_gamma) for i in range(nbin_source)]
+            # 2d calibrator
+            calibrators.append(ParallelCalibratorMetacal(self.select_2d, delta_gamma))
         else:
             calibrators = [ParallelCalibratorNonMetacal(self.select) for i in range(nbin_source)]
+            calibrators.append(ParallelCalibratorNNonMetacal(self.select_2d))
 
         # Loop through the input data, processing it chunk by chunk
         for (start, end, shear_data) in iter_shear:
@@ -328,7 +331,7 @@ class TXSourceSelector(PipelineStage):
             R = np.zeros((n,))
 
         # We also keep count of total count of objects in each bin
-        counts = np.zeros(nbin, dtype=int)
+        counts = np.zeros(nbin + 1, dtype=int)
 
         data = {**pz_data, **shear_data}
         
@@ -345,7 +348,14 @@ class TXSourceSelector(PipelineStage):
         for i in range(nbin):
             sel_00 = calibrators[i].add_data(data, i)
             tomo_bin[sel_00] = i
-            counts[i] = sel_00.sum()
+            nsum = sel_00.sum()
+            counts[i] = nsum
+            # also count up the 2D sample
+            counts[-1] += nsum
+
+        # and calibrate the 2D sample.
+        # This calibrator refers to self.select_2d
+        calibrators[-1].add_data(data)
 
         return tomo_bin, R, counts
 
@@ -364,10 +374,15 @@ class TXSourceSelector(PipelineStage):
         group = outfile.create_group('tomography')
         group.create_dataset('source_bin', (n,), dtype='i')
         group.create_dataset('source_counts', (nbin_source,), dtype='i')
+        group.create_dataset('source_counts_2d', (1,), dtype='i')
         group.create_dataset('sigma_e', (nbin_source,), dtype='f')
+        group.create_dataset('sigma_e_2d', (1,), dtype='f')
         group.create_dataset('mean_e1', (nbin_source,), dtype='f')
         group.create_dataset('mean_e2', (nbin_source,), dtype='f')
+        group.create_dataset('mean_e1_2d', (1,), dtype='f')
+        group.create_dataset('mean_e2_2d', (1,), dtype='f')
         group.create_dataset('N_eff', (nbin_source,), dtype='f')
+        group.create_dataset('N_eff_2d', (1,), dtype='f')
 
         group.attrs['nbin_source'] = nbin_source
         for i in range(nbin_source):
@@ -381,12 +396,18 @@ class TXSourceSelector(PipelineStage):
             group.create_dataset('R_S', (nbin_source,2,2), dtype='f')
             group.create_dataset('R_gamma_mean', (nbin_source,2,2), dtype='f')
             group.create_dataset('R_total', (nbin_source,2,2), dtype='f')
+            group.create_dataset('R_S_2d', (2,2), dtype='f')
+            group.create_dataset('R_gamma_mean_2d', (2,2), dtype='f')
+            group.create_dataset('R_total_2d', (2,2), dtype='f')
         else:
             group = outfile.create_group('response') 
             group.create_dataset('R', (n,), dtype='f')
             group.create_dataset('K', (nbin_source,), dtype='f')
             group.create_dataset('C', (nbin_source,1,2), dtype='f')
             group.create_dataset('R_mean', (nbin_source,), dtype='f')
+            group.create_dataset('K_2d', (1,), dtype='f')
+            group.create_dataset('C_2d', (1,2), dtype='f')
+            group.create_dataset('R_mean_2d', (1,), dtype='f')
 
         return outfile
 
@@ -435,7 +456,7 @@ class TXSourceSelector(PipelineStage):
         S: array of shape (nbin,2,2)
             Selection bias matrices
         """
-        nbin_source = len(calibrators)
+        nbin_source = len(calibrators) - 1
 
         R = np.zeros((nbin_source, 2, 2))
         S = np.zeros((nbin_source, 2, 2))
@@ -447,10 +468,12 @@ class TXSourceSelector(PipelineStage):
         mean_e2 = np.zeros(nbin_source)
         sigma_e = np.zeros(nbin_source)
 
-        means, variances = number_density_stats.collect()
+        means, variances, means_2d, variances_2d = number_density_stats.collect()
 
-
-        for i, cal in enumerate(calibrators):
+        # Loop through the tomographic calibrators.
+        # (The last calibrator is for the non-tomographic selection)
+        for i in range(nbin_source):
+            cal = calibrators[i]
             mu1 = np.array([means[i, 0]])
             mu2 = np.array([means[i, 1]])
 
@@ -490,42 +513,101 @@ class TXSourceSelector(PipelineStage):
             else:
                 raise ValueError("Unknown calibration type in mean g / sigma_e calc")
 
+        # The non-tomographic parts
+        cal2d = calibrators[-1]
+        mu1 = np.array([means_2d[0]])
+        mu2 = np.array([means_2d[1]])
+
+        # Non-tomo metacal
+        if self.config['shear_catalog_type']=='metacal':
+            R_2d, S_2d, N_2d = cal2d.collect(self.comm)
+
+            mean_e1_2d, mean_e2_2d = apply_metacal_response(
+                R_2d, S_2d, g1=mu1, g2=mu2)
+
+            # non-tomo sigma_e in metacal
+            P = np.diag(np.linalg.inv(R_2d @ R_2d))
+            sigma_e_2d = np.sqrt(0.5 * P @ variances_2d)
+
+        # Non-tomo lensfit
+        elif self.config['shear_catalog_type']=='lensfit':
+            print("(also check in the 2D bit!)")
+            R_scalar_2d, K_2d, C_2d, N_2d = cal2d.collect(self.comm)
+
+            # should probably use one of the calibration_tools functions
+            mean_e1_2d = mu1 / R_scalar_2d
+            mean_e2_2d = mu2 / R_scalar_2d
+            # non-tomo sigma_e in lensfit
+            sigma_e_2d = np.sqrt(
+                (0.5 * (variances_2d[0] + variances_2d[1]))
+            ) / R_scalar_2d
+
+
+
         if self.rank==0:
             if self.config['shear_catalog_type']=='metacal':
                 group = outfile['metacal_response']
+                # Tomographic outputs
                 group['R_S'][:,:,:] = S
                 group['R_gamma_mean'][:,:,:] = R
                 group['R_total'][:,:,:] = R + S
-                group = outfile['tomography']
-                group['sigma_e'][:] = sigma_e
-                # These are the same in metacal
-                group['source_counts'][:] = N
-                group['N_eff'][:] = N
-                group['mean_e1'][:] = mean_e1
-                group['mean_e2'][:] = mean_e2
+
+                # Non-tomographic outputs
+                group['R_S_2d'][:,:] = S_2d
+                group['R_gamma_mean_2d'][:,:] = R_2d
+                group['R_total_2d'][:,:] = R_2d + S_2d
             else:
                 group = outfile['response']
+                # Tomographic outputs
                 group['R_mean'][:] = R_scalar
                 group['C'][:] = C
                 group['K'][:] = K
-                group = outfile['tomography']
-                group['sigma_e'][:] = sigma_e
-                # These are the same in metacal
-                group['source_counts'][:] = N
-                group['N_eff'][:] = N
-                group['mean_e1'][:] = mean_e1
-                group['mean_e2'][:] = mean_e2
+
+                # Non-tomographic outputs
+                group['R_mean_2d'][:] = R_scalar_2d
+                group['C_2d'][:] = C_2d
+                group['K_2d'][:] = K_2d
+
+            # These are the same in the two methods
+            group = outfile['tomography']
+
+            group['source_counts'][:] = N
+            group['N_eff'][:] = N
+            group['mean_e1'][:] = mean_e1
+            group['mean_e2'][:] = mean_e2
+            group['sigma_e'][:] = sigma_e
+
+            # and the non-tomographic versions of the same things
+            group['source_counts_2d'][:] = N_2d
+            group['N_eff_2d'][:] = N_2d
+            group['mean_e1_2d'][:] = mean_e1_2d
+            group['mean_e2_2d'][:] = mean_e2_2d
+            group['sigma_e_2d'][:] = sigma_e_2d
 
     
     def select(self, data, bin_index):
+        zbin = data['zbin']
+        verbose = self.config['verbose']
+
+        sel = self.select_2d(data, is_2d=False)
+        sel &= zbin==bin_index
+        f4 = sel.sum() / sel.size
+
+        if verbose:
+            print(f"{f4:.2%} z for bin {bin_index}")
+
+        return sel
+
+    def select_2d(self, data, is_2d=True):
+        # Select any objects that pass general WL cuts
         shear_prefix = self.config['shear_prefix']
         s2n_cut = self.config['s2n_cut']
         T_cut = self.config['T_cut']
         verbose = self.config['verbose']
+        variant = data.suffix
 
         s2n = data[f'{shear_prefix}s2n']
         T = data[f'{shear_prefix}T']
-        zbin = data['zbin']
 
         Tpsf = data[f'{shear_prefix}psf_T_mean']
         flag = data[f'{shear_prefix}flags']
@@ -537,13 +619,17 @@ class TXSourceSelector(PipelineStage):
         f2 = sel.sum() / n0
         sel &= s2n>s2n_cut
         f3 = sel.sum() / n0
-        sel &= zbin==bin_index
-        f4 = sel.sum() / n0
-        
-        variant = data.suffix
-        if verbose:
-            print(f"Bin {bin_index} ({variant}) {f1:.2%} flag, {f2:.2%} size, {f3:.2%} SNR, {f4:.2%} z")
 
+        # Print out a message.  If we are selecting a 2D sample
+        # this is the complete message.  Otherwise if we are about
+        # to also apply a redshift bin cut about then the message will continue
+        # as above
+        if verbose and is_2d:
+            print(f"2D selection ({variant}) {f1:.2%} flag, {f2:.2%} size, "
+                  f"{f3:.2%} SNR")
+        elif verbose:
+            print(f"Tomo selection ({variant}) {f1:.2%} flag, {f2:.2%} size, "
+                  f"{f3:.2%} SNR, ", end="")
         return sel
 
 

--- a/txpipe/source_selector.py
+++ b/txpipe/source_selector.py
@@ -137,7 +137,7 @@ class TXSourceSelector(PipelineStage):
             calibrators.append(ParallelCalibratorMetacal(self.select_2d, delta_gamma))
         else:
             calibrators = [ParallelCalibratorNonMetacal(self.select) for i in range(nbin_source)]
-            calibrators.append(ParallelCalibratorNNonMetacal(self.select_2d))
+            calibrators.append(ParallelCalibratorNonMetacal(self.select_2d))
 
         # Loop through the input data, processing it chunk by chunk
         for (start, end, shear_data) in iter_shear:

--- a/txpipe/utils/number_density_stats.py
+++ b/txpipe/utils/number_density_stats.py
@@ -10,17 +10,24 @@ class SourceNumberDensityStats:
             ParallelMeanVariance(2)
             for i in range(nbin_source)
         ]
+        self.shear_stats_2d = ParallelMeanVariance(2)
 
     def add_data(self, shear_data, shear_bin):
+
         for i in range(self.nbin_source):
             w = np.where(shear_bin==i)
 
             if self.shear_type=='metacal':
                 self.shear_stats[i].add_data(0, shear_data['mcal_g1'][w], shear_data['weight'][w])
                 self.shear_stats[i].add_data(1, shear_data['mcal_g2'][w], shear_data['weight'][w])
+                # each bin contributes to the 2D
+                self.shear_stats_2d.add_data(0, shear_data['mcal_g1'][w], shear_data['weight'][w])
+                self.shear_stats_2d.add_data(1, shear_data['mcal_g2'][w], shear_data['weight'][w])
             else:
                 self.shear_stats[i].add_data(0, shear_data['g1'][w], shear_data['weight'][w])
                 self.shear_stats[i].add_data(1, shear_data['g2'][w], shear_data['weight'][w])
+                self.shear_stats_2d.add_data(0, shear_data['g1'][w], shear_data['weight'][w])
+                self.shear_stats_2d.add_data(1, shear_data['g2'][w], shear_data['weight'][w])
 
 
     def collect(self):
@@ -31,7 +38,8 @@ class SourceNumberDensityStats:
         for i in range(self.nbin_source):
             _, means[i], variances[i] = self.shear_stats[i].collect(self.comm, mode='allgather')
 
-        return means, variances
+        _, means2d, variances2d = self.shear_stats_2d.collect(self.comm, mode='allgather')
+        return means, variances, means2d, variances2d
 
 
 class LensNumberDensityStats:
@@ -39,17 +47,21 @@ class LensNumberDensityStats:
         self.nbin_lens = nbin_lens
         self.comm = comm
         self.lens_counts = np.zeros(nbin_lens)
+        self.lens_counts_2d = 0.0
 
     def add_data(self, lens_bin):
 
         for i in range(self.nbin_lens):
             n = (lens_bin==i).sum()
             self.lens_counts[i] += n
+            # each bin contributes to the 2D case
+            self.lens_counts_2d += n
 
     def collect(self):
 
         if self.comm is None:
             lens_counts = self.lens_counts
+            lens_counts_2d = self.lens_counts_2d
         else:
             import mpi4py.MPI
             lens_counts = np.zeros_like(self.lens_counts)
@@ -60,5 +72,11 @@ class LensNumberDensityStats:
                 root = 0
             )
 
-        return lens_counts
+            lens_counts_2d = self.comm.reduce(
+                self.lens_counts_2d,
+                op = mpi4py.MPI.SUM,
+                root = 0
+            )
+
+        return lens_counts, lens_counts_2d
 


### PR DESCRIPTION
This change adds non-tomographic source and lens bins, for example for correlating with systematics.

It:
- adds the counts to the number density stats (simple)
- saves them in the lens selector (simple)
- (added) add 2d counts in redmagic ingest
- makes and calibrates the 2D source map (medium)
- adds a new 2D calibrator for the source selector, reorganizing the selection to avoid copy-paste selections (fiddly)
- reorganizes metadata output slightly (bit fiddly)
