### PR TITLE
Gamma x

### DIFF
--- a/examples/laptop_pipeline.yml
+++ b/examples/laptop_pipeline.yml
@@ -32,7 +32,6 @@ stages:
     - name: TXPSFDiagnostics     # Compute and plots other PSF diagnostics
     - name: TXBrighterFatterPlot # Make plots tracking the brighter-fatter effect
     - name: TXPhotozPlots        # Plot the bin n(z)
-    #- name: TXTwoPGXP            # Plot the gammaX correlation
 
     # These two require the WLMassMap repository on the path - see below
     # - name: TXConvergenceMaps

--- a/examples/laptop_pipeline.yml
+++ b/examples/laptop_pipeline.yml
@@ -32,7 +32,7 @@ stages:
     - name: TXPSFDiagnostics     # Compute and plots other PSF diagnostics
     - name: TXBrighterFatterPlot # Make plots tracking the brighter-fatter effect
     - name: TXPhotozPlots        # Plot the bin n(z)
-    - name: TXTwoPGXP            # Plot the gammaX correlation
+    #- name: TXTwoPGXP            # Plot the gammaX correlation
 
     # These two require the WLMassMap repository on the path - see below
     # - name: TXConvergenceMaps

--- a/examples/laptop_pipeline.yml
+++ b/examples/laptop_pipeline.yml
@@ -32,6 +32,7 @@ stages:
     - name: TXPSFDiagnostics     # Compute and plots other PSF diagnostics
     - name: TXBrighterFatterPlot # Make plots tracking the brighter-fatter effect
     - name: TXPhotozPlots        # Plot the bin n(z)
+    - name: TXTwoPGXP            # Plot the gammaX correlation
 
     # These two require the WLMassMap repository on the path - see below
     # - name: TXConvergenceMaps

--- a/txpipe/plotting/correlations.py
+++ b/txpipe/plotting/correlations.py
@@ -80,7 +80,7 @@ def full_3x2pt_plots(sacc_files, labels,
             sacc_data.append(f)
         else:
             sacc_data.append(sacc.Sacc.load_fits(f))
-
+    print(sacc_data)
     obs_data = [extract_observables_plot_data(s, label) for s, label in zip(sacc_data, labels)]
     plot_theory = (cosmo is not None)
 

--- a/txpipe/plotting/correlations.py
+++ b/txpipe/plotting/correlations.py
@@ -262,7 +262,7 @@ def make_plot(corr, obs_data, theory_data, fig=None, xlogscale=True):
     f.suptitle(rf"TXPipe ${name}$")
 
     # plt.tight_layout()
-    f.tight_layout(rect=[0, 0.03, 1, 0.95])
+    #f.tight_layout(rect=[0, 0.03, 1, 0.95])
     plt.subplots_adjust(wspace=0.05, hspace=0.05)
     return plt.gcf()
 

--- a/txpipe/plotting/correlations.py
+++ b/txpipe/plotting/correlations.py
@@ -80,7 +80,7 @@ def full_3x2pt_plots(sacc_files, labels,
             sacc_data.append(f)
         else:
             sacc_data.append(sacc.Sacc.load_fits(f))
-    print(sacc_data)
+            
     obs_data = [extract_observables_plot_data(s, label) for s, label in zip(sacc_data, labels)]
     plot_theory = (cosmo is not None)
 

--- a/txpipe/plotting/correlations.py
+++ b/txpipe/plotting/correlations.py
@@ -207,7 +207,7 @@ def make_plot(corr, obs_data, theory_data, fig=None, xlogscale=True):
     elif corr == GAMMAX:
         ymin = 5e-7
         ymax = 2e-2
-        name r'\gamma_X(\theta)'
+        name = r"\gamma_X(\theta)"
         auto_only = True
         half_only = False
 

--- a/txpipe/plotting/correlations.py
+++ b/txpipe/plotting/correlations.py
@@ -208,7 +208,7 @@ def make_plot(corr, obs_data, theory_data, fig=None, xlogscale=True):
         ymin = 5e-7
         ymax = 2e-2
         name = r"\gamma_X(\theta)"
-        auto_only = True
+        auto_only = False
         half_only = False
 
     plt.rcParams['font.size'] = 14

--- a/txpipe/plotting/correlations.py
+++ b/txpipe/plotting/correlations.py
@@ -3,6 +3,7 @@ import copy
 
 W = "galaxy_density_xi"
 GAMMA = "galaxy_shearDensity_xi_t"
+GAMMAX = "galaxy_shearDensity_xi_x"
 XIP = "galaxy_shear_xi_plus"
 XIM = "galaxy_shear_xi_minus"
 EE = "galaxy_shear_cl_ee"
@@ -12,6 +13,7 @@ ED = "galaxy_shearDensity_cl_e"
 types = {
     W: ('theta','lens','lens'),
     GAMMA: ('theta','source','lens'),
+    GAMMAX: ('theta','source','lens'),
     XIP: ('theta','source','source'),
     XIM: ('theta','source','source'),
     EE: ('ell', 'source','source'),
@@ -200,6 +202,12 @@ def make_plot(corr, obs_data, theory_data, fig=None, xlogscale=True):
         ymin = 2e-8
         ymax = 1e-4
         name = r"C_\ell^{DD}"
+        auto_only = True
+        half_only = False
+    elif corr == GAMMAX:
+        ymin = 5e-7
+        ymax = 2e-2
+        name r'\gamma_X(\theta)'
         auto_only = True
         half_only = False
 

--- a/txpipe/twopoint.py
+++ b/txpipe/twopoint.py
@@ -757,6 +757,7 @@ class TXTwoPointPlots(PipelineStage):
     inputs = [
         ('twopoint_data_real', SACCFile),
         ('fiducial_cosmology', YamlFile),  # For example lines
+        ('shearposX', SACCFile),
     ]
     outputs = [
         ('shear_xi_plus', PNGFile),
@@ -781,7 +782,7 @@ class TXTwoPointPlots(PipelineStage):
         matplotlib.rcParams["xtick.direction"]='in'
         matplotlib.rcParams["ytick.direction"]='in'
 
-        filename = self.get_input('twopoint_data_real')
+        filename = self.get_input('twopoint_data_real','shearposX')
         s = sacc.Sacc.load_fits(filename)
         nbin_source, nbin_lens = self.read_nbin(s)
 

--- a/txpipe/twopoint.py
+++ b/txpipe/twopoint.py
@@ -335,7 +335,8 @@ class TXTwoPoint(PipelineStage):
                     for i in range(n):
                         S2.add_data_point(GAMMAX, (tracer1,tracer2), xi_x[i],
                             theta=theta[i], error=err[i], weight=weight[i])
-            S2.add_covariance(comb)
+                    s2.add_covariance(covX)
+            #S2.add_covariance(comb)
             S2.to_canonical_order
             self.write_metadata(S2,meta)
             S2.save_fits(self.get_output('shearposX'), overwrite=True)

--- a/txpipe/twopoint.py
+++ b/txpipe/twopoint.py
@@ -766,6 +766,7 @@ class TXTwoPointPlots(PipelineStage):
         ('shear_xi_minus', PNGFile),
         ('shearDensity_xi', PNGFile),
         ('density_xi', PNGFile),
+        ('shearDensity_xi_x', PNGFile),
     ]
 
     config_options = {
@@ -801,6 +802,9 @@ class TXTwoPointPlots(PipelineStage):
 
             "galaxy_shear_xi_minus": self.open_output('shear_xi_minus',
                 figsize=(3.5*nbin_source, 3*nbin_source), wrapper=True),
+            
+            "galaxy_shearDensity_xi_x": self.open_output('shearDensity_xi_x',
+                figsize=(3.5*nbin_lens, 3*nbin_source), wrapper=True),
         }
 
         figures = {key: val.file for key, val in outputs.items()}

--- a/txpipe/twopoint.py
+++ b/txpipe/twopoint.py
@@ -823,6 +823,9 @@ class TXTwoPointPlots(PipelineStage):
         full_3x2pt_plots([filename], ['shearposX'], 
             figures=figures)
 
+        for fig in outputs.values():
+            fig.close()
+
     def read_nbin(self, s):
         import sacc
 

--- a/txpipe/twopoint.py
+++ b/txpipe/twopoint.py
@@ -782,7 +782,7 @@ class TXTwoPointPlots(PipelineStage):
         matplotlib.rcParams["xtick.direction"]='in'
         matplotlib.rcParams["ytick.direction"]='in'
 
-        filename = self.get_input('twopoint_data_real','shearposX')
+        filename = self.get_input('twopoint_data_real')
         s = sacc.Sacc.load_fits(filename)
         nbin_source, nbin_lens = self.read_nbin(s)
 
@@ -801,8 +801,6 @@ class TXTwoPointPlots(PipelineStage):
             "galaxy_shear_xi_minus": self.open_output('shear_xi_minus',
                 figsize=(3.5*nbin_source, 3*nbin_source), wrapper=True),
             
-            "galaxy_shearDensity_xi_x": self.open_output('shearDensity_xi_x',
-                figsize=(3.5*nbin_lens, 3*nbin_source), wrapper=True),
         }
 
         figures = {key: val.file for key, val in outputs.items()}
@@ -812,6 +810,18 @@ class TXTwoPointPlots(PipelineStage):
 
         for fig in outputs.values():
             fig.close()
+
+        filename = self.get_input('shearposX')
+
+        outputs = {
+            "galaxy_shearDensity_xi_x": self.open_output('shearDensity_x',
+                figsize=(3.5*nbin_lens, 3*nbin_source), wrapper=True),
+        }
+        
+        figures = {key: val.file for key, val in outputs.items()}
+
+        full_3x2pt_plots([filename], ['shearposX'], 
+            figures=figures)
 
     def read_nbin(self, s):
         import sacc

--- a/txpipe/twopoint.py
+++ b/txpipe/twopoint.py
@@ -1156,7 +1156,7 @@ class TXTwoPointGammaXPlots(TXTwoPointPlots):
 
         outputs = {
             "galaxy_shearDensity_xi_x": self.open_output('shearDensity_x',
-                figsize=(3.5*nbin_lens, 3*nbin_source), wrapper=True)
+                figsize=(3.5*nbin_lens, 3*nbin_source), wrapper=True),
         }
         
         figures = {key: val.file for key, val in outputs.items()}

--- a/txpipe/twopoint.py
+++ b/txpipe/twopoint.py
@@ -1161,7 +1161,7 @@ class TXTwoPointGammaXPlots(TXTwoPointPlots):
         
         figures = {key: val.file for key, val in outputs.items()}
 
-        full_3x2pt_plots([filename], ['twopoint_data_real'], 
+        full_3x2pt_plots([filename], ['shearposX'], 
             figures=figures)
         
         for fig in outputs.values():

--- a/txpipe/twopoint.py
+++ b/txpipe/twopoint.py
@@ -316,7 +316,7 @@ class TXTwoPoint(PipelineStage):
             comb = []
             for d in results:
                 
-                if d.corr_type = GAMMAT:
+                if d.corr_type == GAMMAT:
                     tracer1 = f'source_{d.i}' 
                     tracer2 = f'lens_{d.j}'
                     theta = np.exp(d.object.meanlogr)

--- a/txpipe/twopoint.py
+++ b/txpipe/twopoint.py
@@ -335,12 +335,8 @@ class TXTwoPoint(PipelineStage):
                     for i in range(n):
                         S2.add_data_point(GAMMAX, (tracer1,tracer2), xi_x[i],
                             theta=theta[i], error=err[i], weight=weight[i])
-<<<<<<< HEAD
                     S2.add_covariance(covX)
             #S2.add_covariance(comb)
-=======
-            S2.add_covariance(comb)
->>>>>>> parent of e3cf789... Update twopoint.py
             S2.to_canonical_order
             self.write_metadata(S2,meta)
             S2.save_fits(self.get_output('shearposX'), overwrite=True)

--- a/txpipe/twopoint.py
+++ b/txpipe/twopoint.py
@@ -335,8 +335,7 @@ class TXTwoPoint(PipelineStage):
                     for i in range(n):
                         S2.add_data_point(GAMMAX, (tracer1,tracer2), xi_x[i],
                             theta=theta[i], error=err[i], weight=weight[i])
-                    s2.add_covariance(covX)
-            #S2.add_covariance(comb)
+            S2.add_covariance(comb)
             S2.to_canonical_order
             self.write_metadata(S2,meta)
             S2.save_fits(self.get_output('shearposX'), overwrite=True)

--- a/txpipe/twopoint.py
+++ b/txpipe/twopoint.py
@@ -814,7 +814,7 @@ class TXTwoPointPlots(PipelineStage):
         filename = self.get_input('shearposX')
 
         outputs = {
-            "galaxy_shearDensity_xi_x": self.open_output('shearDensity_x',
+            "galaxy_shearDensity_xi_x": self.open_output('shearDensity_xi_x',
                 figsize=(3.5*nbin_lens, 3*nbin_source), wrapper=True),
         }
         

--- a/txpipe/twopoint.py
+++ b/txpipe/twopoint.py
@@ -756,7 +756,7 @@ class TXTwoPointPlots(PipelineStage):
     name='TXTwoPointPlots'
     inputs = [
         ('twopoint_data_real', SACCFile),
-        ('fiducial_cosmology', YamlFile),  # For example lines
+        ('fiducial_cosmology', FiducialCosmology),  # For example lines
         ('shearposX', SACCFile),
     ]
     outputs = [

--- a/txpipe/twopoint.py
+++ b/txpipe/twopoint.py
@@ -311,7 +311,7 @@ class TXTwoPoint(PipelineStage):
         S.save_fits(self.get_output('twopoint_data_real_raw'), overwrite=True)
         
         # Adding the gammaX calculation:
-        S2.sacc.Sacc()
+        S2 = sacc.Sacc()
         if self.config['do_shear_pos'] == True:
             comb = []
             for d in results:

--- a/txpipe/twopoint.py
+++ b/txpipe/twopoint.py
@@ -1141,6 +1141,7 @@ class TXTwoPointGammaXPlots(TXTwoPointPlots):
     def run(self):
         import sacc
         import matplotlib
+        import pyccl
         from .plotting import full_3x2pt_plots
         matplotlib.use('agg')
         matplotlib.rcParams["xtick.direction"]='in'
@@ -1149,6 +1150,8 @@ class TXTwoPointGammaXPlots(TXTwoPointPlots):
         filename = self.get_input('shearposX')
         s = sacc.Sacc.load_fits(self.get_input('shearposX'))
         nbin_source, nbin_lens = self.read_nbin(s)
+
+        cosmo = pyccl.Cosmology.read_yaml("./data/fiducial_cosmology.yml")
 
         outputs = {
             "galaxy_shearDensity_xi_x": self.open_output('shearDensity_x',

--- a/txpipe/twopoint.py
+++ b/txpipe/twopoint.py
@@ -1152,6 +1152,7 @@ class TXTwoPointGammaXPlots(TXTwoPointPlots):
         outputs = {
             "galaxy_shearDensity_xi_x": self.open_output('shearDensity_xi',
                 figsize=(3.5*nbin_lens, 3*nbin_source), wrapper=True)
+        }
         
         figures = {key: val.file for key, val in outputs.items()}
 

--- a/txpipe/twopoint.py
+++ b/txpipe/twopoint.py
@@ -1142,51 +1142,6 @@ class TXTwoPointPlots(PipelineStage):
             plt.subplots_adjust(hspace=self.config['hspace'],wspace=self.config['wspace'])
             plot_output.close()
 
-class TXTwoPointGammaXPlots(TXTwoPointPlots):
-    name='TXTwoPGXP'
-    inputs = [
-        ('shearposX', SACCFile),
-        ('fiducial_cosmology', YamlFile),
-    ]
-    outputs = [
-        ('shearDensity_x', PNGFile),
-    ]
-
-    config_options = {
-        'wspace': 0.05,
-        'hspace': 0.05,
-    }
-
-    def run(self):
-        import sacc
-        import matplotlib
-        #import pyccl
-        from .plotting import full_3x2pt_plots
-        matplotlib.use('agg')
-        matplotlib.rcParams["xtick.direction"]='in'
-        matplotlib.rcParams["ytick.direction"]='in'
-
-        filename = self.get_input('shearposX')
-        s = sacc.Sacc.load_fits(self.get_input('shearposX'))
-        nbin_source, nbin_lens = self.read_nbin(s)
-
-        #cosmo = pyccl.Cosmology.read_yaml("./data/fiducial_cosmology.yml")
-
-        outputs = {
-            "galaxy_shearDensity_xi_x": self.open_output('shearDensity_x',
-                figsize=(3.5*nbin_lens, 3*nbin_source), wrapper=True),
-        }
-        
-        figures = {key: val.file for key, val in outputs.items()}
-
-        full_3x2pt_plots([filename], ['shearposX'], 
-            figures=figures)
-        
-        for fig in outputs.values():
-            fig.close()
-
-
-
 
 class TXGammaTFieldCenters(TXTwoPoint):
     """

--- a/txpipe/twopoint.py
+++ b/txpipe/twopoint.py
@@ -33,7 +33,7 @@ class TXTwoPoint(PipelineStage):
     ]
     outputs = [
         ('twopoint_data_real_raw', SACCFile),
-        ('shearposX', SACCFile)
+        ('twopoint_gamma_x', SACCFile)
     ]
     # Add values to the config file that are not previously defined
     config_options = {
@@ -339,7 +339,7 @@ class TXTwoPoint(PipelineStage):
             S2.add_covariance(comb)
             S2.to_canonical_order
             self.write_metadata(S2,meta)
-            S2.save_fits(self.get_output('shearposX'), overwrite=True)
+            S2.save_fits(self.get_output('twopoint_gamma_x'), overwrite=True)
 
 
 
@@ -757,7 +757,7 @@ class TXTwoPointPlots(PipelineStage):
     inputs = [
         ('twopoint_data_real', SACCFile),
         ('fiducial_cosmology', FiducialCosmology),  # For example lines
-        ('shearposX', SACCFile),
+        ('twopoint_gamma_x', SACCFile),
     ]
     outputs = [
         ('shear_xi_plus', PNGFile),
@@ -811,7 +811,7 @@ class TXTwoPointPlots(PipelineStage):
         for fig in outputs.values():
             fig.close()
 
-        filename = self.get_input('shearposX')
+        filename = self.get_input('twopoint_gamma_x')
 
         outputs = {
             "galaxy_shearDensity_xi_x": self.open_output('shearDensity_xi_x',
@@ -820,7 +820,7 @@ class TXTwoPointPlots(PipelineStage):
         
         figures = {key: val.file for key, val in outputs.items()}
 
-        full_3x2pt_plots([filename], ['shearposX'], 
+        full_3x2pt_plots([filename], ['twopoint_gamma_x'], 
             figures=figures)
 
         for fig in outputs.values():

--- a/txpipe/twopoint.py
+++ b/txpipe/twopoint.py
@@ -1161,7 +1161,7 @@ class TXTwoPointGammaXPlots(TXTwoPointPlots):
         figures = {key: val.file for key, val in outputs.items()}
 
         full_3x2pt_plots([filename], ['twopoint_data_real'], 
-            figures=figures, theory_labels=['Fiducial'])
+            figures=figures)
         
         for fig in outputs.values():
             fig.close()

--- a/txpipe/twopoint.py
+++ b/txpipe/twopoint.py
@@ -335,7 +335,7 @@ class TXTwoPoint(PipelineStage):
                     for i in range(n):
                         S2.add_data_point(GAMMAX, (tracer1,tracer2), xi_x[i],
                             theta=theta[i], error=err[i], weight=weight[i])
-                    s2.add_covariance(covX)
+                    S2.add_covariance(covX)
             #S2.add_covariance(comb)
             S2.to_canonical_order
             self.write_metadata(S2,meta)

--- a/txpipe/twopoint.py
+++ b/txpipe/twopoint.py
@@ -335,7 +335,7 @@ class TXTwoPoint(PipelineStage):
                     for i in range(n):
                         S2.add_data_point(GAMMAX, (tracer1,tracer2), xi_x[i],
                             theta=theta[i], error=err[i], weight=weight[i])
-                    S2.add_covariance(covX)
+                    s2.add_covariance(covX)
             #S2.add_covariance(comb)
             S2.to_canonical_order
             self.write_metadata(S2,meta)

--- a/txpipe/twopoint.py
+++ b/txpipe/twopoint.py
@@ -312,7 +312,7 @@ class TXTwoPoint(PipelineStage):
         
         # Adding the gammaX calculation:
         S2.sacc.Sacc()
-        if self.config['do_shear_pos'] = True:
+        if self.config['do_shear_pos'] == True:
             comb = []
             for d in results:
                 

--- a/txpipe/twopoint.py
+++ b/txpipe/twopoint.py
@@ -1141,7 +1141,7 @@ class TXTwoPointGammaXPlots(TXTwoPointPlots):
     def run(self):
         import sacc
         import matplotlib
-        import pyccl
+        #import pyccl
         from .plotting import full_3x2pt_plots
         matplotlib.use('agg')
         matplotlib.rcParams["xtick.direction"]='in'
@@ -1151,7 +1151,7 @@ class TXTwoPointGammaXPlots(TXTwoPointPlots):
         s = sacc.Sacc.load_fits(self.get_input('shearposX'))
         nbin_source, nbin_lens = self.read_nbin(s)
 
-        cosmo = pyccl.Cosmology.read_yaml("./data/fiducial_cosmology.yml")
+        #cosmo = pyccl.Cosmology.read_yaml("./data/fiducial_cosmology.yml")
 
         outputs = {
             "galaxy_shearDensity_xi_x": self.open_output('shearDensity_x',
@@ -1161,7 +1161,7 @@ class TXTwoPointGammaXPlots(TXTwoPointPlots):
         figures = {key: val.file for key, val in outputs.items()}
 
         full_3x2pt_plots([filename], ['twopoint_data_real'], 
-            figures=figures, cosmo=cosmo, theory_labels=['Fiducial'])
+            figures=figures, theory_labels=['Fiducial'])
         
         for fig in outputs.values():
             fig.close()

--- a/txpipe/twopoint.py
+++ b/txpipe/twopoint.py
@@ -230,8 +230,8 @@ class TXTwoPoint(PipelineStage):
         WTHETA = sacc.standard_types.galaxy_density_xi
 
         S = sacc.Sacc()
-        #if self.config['do_shear_pos'] == True:
-        #    S2 = sacc.Sacc()
+        if self.config['do_shear_pos'] == True:
+            S2 = sacc.Sacc()
 
         # We include the n(z) data in the output.
         # So here we load it in and add it to the data
@@ -243,8 +243,8 @@ class TXTwoPoint(PipelineStage):
             z = f['n_of_z/source/z'][:]
             Nz = f[f'n_of_z/source/bin_{i}'][:]
             S.add_tracer('NZ', f'source_{i}', z, Nz)
-            #if self.config['do_shear_pos'] == True:
-            #    S2.add_tracer('NZ', f'source_{i}',z, Nz)
+            if self.config['do_shear_pos'] == True:
+                S2.add_tracer('NZ', f'source_{i}',z, Nz)
 
         f = self.open_input('lens_photoz_stack')
         # For both source and lens
@@ -252,8 +252,8 @@ class TXTwoPoint(PipelineStage):
             z = f['n_of_z/lens/z'][:]
             Nz = f[f'n_of_z/lens/bin_{i}'][:]
             S.add_tracer('NZ', f'lens_{i}', z, Nz)
-            #if self.config['do_shear_pos'] == True:
-            #    S2.add_tracer('NZ', f'lens_{i}',z, Nz)
+            if self.config['do_shear_pos'] == True:
+                S2.add_tracer('NZ', f'lens_{i}',z, Nz)
         # Closing n(z) file
         f.close()
 
@@ -305,13 +305,21 @@ class TXTwoPoint(PipelineStage):
         # Add the covariance.  There are several different jackknife approaches
         # available - see the treecorr docs
         cov = treecorr.estimate_multi_cov(comb, self.config['var_methods'])
-        #S.add_covariance(cov)
+        S.add_covariance(cov)
 
+        # Our data points may currently be in any order depending on which processes
+        # ran which calculations.  Re-order them.
+        S.to_canonical_order()
+
+        self.write_metadata(S,meta)
+
+        # Finally, save the output to Sacc file
+        S.save_fits(self.get_output('twopoint_data_real_raw'), overwrite=True)
         
         # Adding the gammaX calculation:
         
         if self.config['do_shear_pos'] == True:
-            comb = [cov]
+            comb = []
             for d in results:
                 tracer1 = f'source_{d.i}' if d.corr_type in [XI, GAMMAT] else f'lens_{d.i}'
                 tracer2 = f'source_{d.j}' if d.corr_type in [XI] else f'lens_{d.j}'   
@@ -326,24 +334,13 @@ class TXTwoPoint(PipelineStage):
                     err = np.sqrt(np.diag(covX))
                     n = len(xi_x)
                     for i in range(n):
-                        S.add_data_point(GAMMAX, (tracer1,tracer2), xi_x[i],
+                        S2.add_data_point(GAMMAX, (tracer1,tracer2), xi_x[i],
                             theta=theta[i], error=err[i], weight=weight[i])
-            S.add_covariance(comb)
-            #S2.to_canonical_order
-            #self.write_metadata(S2,meta)
-            #S2.save_fits(self.get_output('shearposX'), overwrite=True)
-        else:
-            S.add_covariance(cov)
+            S2.add_covariance(comb)
+            S2.to_canonical_order
+            self.write_metadata(S2,meta)
+            S2.save_fits(self.get_output('shearposX'), overwrite=True)
 
-        # Our data points may currently be in any order depending on which processes
-        # ran which calculations.  Re-order them.
-        S.to_canonical_order()
-
-        self.write_metadata(S,meta)
-
-        # Finally, save the output to Sacc file
-        S.save_fits(self.get_output('twopoint_data_real_raw'), overwrite=True)
-        
 
 
     def write_metadata(self, S, meta):
@@ -1154,7 +1151,6 @@ class TXTwoPointGammaXPlots(TXTwoPointPlots):
         matplotlib.use('agg')
         matplotlib.rcParams["xtick.direction"]='in'
         matplotlib.rcParams["ytick.direction"]='in'
-        import matplotlib.pyplot as plt
 
         filename = self.get_input('shearposX')
         s = sacc.Sacc.load_fits(self.get_input('shearposX'))
@@ -1174,8 +1170,6 @@ class TXTwoPointGammaXPlots(TXTwoPointPlots):
         
         for fig in outputs.values():
             fig.close()
-
-        
 
 
 

--- a/txpipe/twopoint.py
+++ b/txpipe/twopoint.py
@@ -1123,6 +1123,46 @@ class TXTwoPointPlots(PipelineStage):
             plt.subplots_adjust(hspace=self.config['hspace'],wspace=self.config['wspace'])
             plot_output.close()
 
+class TXTwoPointGammaXPlots(TXTwoPointPlots):
+    name='TXTwoPGXP'
+    inputs = [
+        ('shearposX', SACCFile),
+        ('fiducial_cosmology', YamlFile),
+    ]
+    outputs = [
+        ('shearDensity_x', PNGFile),
+    ]
+
+    config_options = {
+        'wspace': 0.05,
+        'hspace': 0.05,
+    }
+
+    def run(self):
+        import sacc
+        import matplotlib
+        from .plotting import full_3x2pt_plots
+        matplotlib.use('agg')
+        matplotlib.rcParams["xtick.direction"]='in'
+        matplotlib.rcParams["ytick.direction"]='in'
+
+        s = sacc.Sacc.load_fits(self.get_input('shearposX'))
+        nbin_source, nbin_lens = self.read_nbin(s)
+
+        outputs = {
+            "galaxy_shearDensity_xi_x": self.open_output('shearDensity_xi',
+                figsize=(3.5*nbin_lens, 3*nbin_source), wrapper=True)
+        
+        figures = {key: val.file for key, val in outputs.items()}
+
+        full_3x2pt_plots([filename], ['twopoint_data_real'], 
+            figures=figures, cosmo=cosmo, theory_labels=['Fiducial'])
+        
+        for fig in outputs.values():
+            fig.close()
+
+
+
 
 class TXGammaTFieldCenters(TXTwoPoint):
     """

--- a/txpipe/twopoint.py
+++ b/txpipe/twopoint.py
@@ -335,8 +335,12 @@ class TXTwoPoint(PipelineStage):
                     for i in range(n):
                         S2.add_data_point(GAMMAX, (tracer1,tracer2), xi_x[i],
                             theta=theta[i], error=err[i], weight=weight[i])
+<<<<<<< HEAD
                     S2.add_covariance(covX)
             #S2.add_covariance(comb)
+=======
+            S2.add_covariance(comb)
+>>>>>>> parent of e3cf789... Update twopoint.py
             S2.to_canonical_order
             self.write_metadata(S2,meta)
             S2.save_fits(self.get_output('shearposX'), overwrite=True)

--- a/txpipe/twopoint.py
+++ b/txpipe/twopoint.py
@@ -1146,6 +1146,7 @@ class TXTwoPointGammaXPlots(TXTwoPointPlots):
         matplotlib.rcParams["xtick.direction"]='in'
         matplotlib.rcParams["ytick.direction"]='in'
 
+        filename = self.get_input('shearposX')
         s = sacc.Sacc.load_fits(self.get_input('shearposX'))
         nbin_source, nbin_lens = self.read_nbin(s)
 

--- a/txpipe/twopoint.py
+++ b/txpipe/twopoint.py
@@ -315,10 +315,10 @@ class TXTwoPoint(PipelineStage):
         if self.config['do_shear_pos'] == True:
             comb = []
             for d in results:
+                tracer1 = f'source_{d.i}' if d.corr_type in [XI, GAMMAT] else f'lens_{d.i}'
+                tracer2 = f'source_{d.j}' if d.corr_type in [XI] else f'lens_{d.j}'   
                 
                 if d.corr_type == GAMMAT:
-                    tracer1 = f'source_{d.i}' 
-                    tracer2 = f'lens_{d.j}'
                     theta = np.exp(d.object.meanlogr)
                     npair = d.object.npairs
                     weight = d.object.weight

--- a/txpipe/twopoint.py
+++ b/txpipe/twopoint.py
@@ -230,6 +230,8 @@ class TXTwoPoint(PipelineStage):
         WTHETA = sacc.standard_types.galaxy_density_xi
 
         S = sacc.Sacc()
+        if self.config['do_shear_pos'] == True:
+            S2 = sacc.Sacc()
 
         # We include the n(z) data in the output.
         # So here we load it in and add it to the data
@@ -241,6 +243,8 @@ class TXTwoPoint(PipelineStage):
             z = f['n_of_z/source/z'][:]
             Nz = f[f'n_of_z/source/bin_{i}'][:]
             S.add_tracer('NZ', f'source_{i}', z, Nz)
+            if self.config['do_shear_pos'] == True:
+                S2.add_tracer('NZ', f'source_{i}',z, Nz)
 
         f = self.open_input('lens_photoz_stack')
         # For both source and lens
@@ -248,6 +252,8 @@ class TXTwoPoint(PipelineStage):
             z = f['n_of_z/lens/z'][:]
             Nz = f[f'n_of_z/lens/bin_{i}'][:]
             S.add_tracer('NZ', f'lens_{i}', z, Nz)
+            if self.config['do_shear_pos'] == True:
+                S2.add_tracer('NZ', f'lens_{i}',z, Nz)
         # Closing n(z) file
         f.close()
 
@@ -311,7 +317,7 @@ class TXTwoPoint(PipelineStage):
         S.save_fits(self.get_output('twopoint_data_real_raw'), overwrite=True)
         
         # Adding the gammaX calculation:
-        S2 = sacc.Sacc()
+        
         if self.config['do_shear_pos'] == True:
             comb = []
             for d in results:

--- a/txpipe/twopoint.py
+++ b/txpipe/twopoint.py
@@ -1150,7 +1150,7 @@ class TXTwoPointGammaXPlots(TXTwoPointPlots):
         nbin_source, nbin_lens = self.read_nbin(s)
 
         outputs = {
-            "galaxy_shearDensity_xi_x": self.open_output('shearDensity_xi',
+            "galaxy_shearDensity_xi_x": self.open_output('shearDensity_x',
                 figsize=(3.5*nbin_lens, 3*nbin_source), wrapper=True)
         }
         

--- a/txpipe/twopoint.py
+++ b/txpipe/twopoint.py
@@ -332,6 +332,7 @@ class TXTwoPoint(PipelineStage):
                     covX = d.object.estimate_cov('shot')
                     comb.append(covX)
                     err = np.sqrt(np.diag(covX))
+                    n = len(xi_x)
                     for i in range(n):
                         S2.add_data_point(GAMMAX, (tracer1,tracer2), xi_x[i],
                             theta=theta[i], error=err[i], weight=weight[i])


### PR DESCRIPTION
This pull request ensures we save the GammaX correlations from TreeCorr.

- It saves the GammaX to a separate sacc file.
- It uses the shot noise from TreeCorr to calculate the error and the covariance.
- When plotting with the stage TwoPointPlots, it now also plots the GammaX.