### PR TITLE
Ell binning and plots

### DIFF
--- a/examples/config/cosmodc2_config.yml
+++ b/examples/config/cosmodc2_config.yml
@@ -133,7 +133,6 @@ TXTwoPointFourier:
     chunk_rows: 100000
     flip_g2: True
     flip_g1: True
-    bandwidth: 200
     apodization_size: 0.0
     cache_dir: ./cache
     

--- a/txpipe/twopoint_fourier.py
+++ b/txpipe/twopoint_fourier.py
@@ -454,7 +454,7 @@ class TXTwoPointFourier(PipelineStage):
 
         # Creating the ell binning from the edges using this Namaster constructor.
         edges = np.unique(np.geomspace(self.config['ell_min'], self.config['ell_max'], self.config['n_ell']).astype(int))
-        ell_bins = MyNmtBin.from_edges(edges_int[:-1], edges_int[1:], is_Dell=False)
+        ell_bins = MyNmtBin.from_edges(edges[:-1], edges[1:], is_Dell=False)
         return ell_bins
 
 

--- a/txpipe/twopoint_fourier.py
+++ b/txpipe/twopoint_fourier.py
@@ -60,7 +60,6 @@ class TXTwoPointFourier(PipelineStage):
 
     config_options = {
         "mask_threshold": 0.0,
-        "bandwidth": 0,
         "flip_g1": False,
         "flip_g2": False,
         "cache_dir": '',
@@ -453,7 +452,11 @@ class TXTwoPointFourier(PipelineStage):
         # Can feed these back upstream if useful.
 
         # Creating the ell binning from the edges using this Namaster constructor.
-        edges = np.unique(np.geomspace(self.config['ell_min'], self.config['ell_max'], self.config['n_ell']).astype(int))
+        if self.config['ell_spacing'] == 'log': 
+            edges = np.unique(np.geomspace(self.config['ell_min'], self.config['ell_max'], self.config['n_ell']).astype(int))
+        else:
+            edges = np.unique(np.linspace(self.config['ell_min'], self.config['ell_max'], self.config['n_ell']).astype(int))
+            
         ell_bins = MyNmtBin.from_edges(edges[:-1], edges[1:], is_Dell=False)
         return ell_bins
 

--- a/txpipe/twopoint_fourier.py
+++ b/txpipe/twopoint_fourier.py
@@ -67,8 +67,8 @@ class TXTwoPointFourier(PipelineStage):
         "deproject_syst_clustering": False,
         "systmaps_clustering_dir": '',
         "ell_min": 100,
-        "ell_max": 3000,
-        "n_ell": 25,
+        "ell_max": 1500,
+        "n_ell": 20,
         "ell_spacing": 'log'
     }
 

--- a/txpipe/twopoint_fourier.py
+++ b/txpipe/twopoint_fourier.py
@@ -453,8 +453,7 @@ class TXTwoPointFourier(PipelineStage):
         # Can feed these back upstream if useful.
 
         # Creating the ell binning from the edges using this Namaster constructor.
-        edges = np.geomspace(self.config['ell_min'], self.config['ell_max'], self.config['n_ell'])
-        edges_int = edges.astype(int)
+        edges = np.unique(np.geomspace(self.config['ell_min'], self.config['ell_max'], self.config['n_ell']).astype(int))
         ell_bins = MyNmtBin.from_edges(edges_int[:-1], edges_int[1:], is_Dell=False)
         return ell_bins
 

--- a/txpipe/utils/nmt_utils.py
+++ b/txpipe/utils/nmt_utils.py
@@ -28,8 +28,8 @@ class MyNmtBinFlat(nmt.NmtBinFlat):
         return c_ell[b0:b1+1].mean()
 
 class MyNmtBin(nmt.NmtBin):
-    def __init__(self, nside, bpws=None, ells=None, weights=None, nlb=None, lmax=None):
-        super().__init__(nside, bpws=bpws, ells=ells, weights=weights, nlb=nlb, lmax=lmax)
+    def __init__(self, nside=None, bpws=None, ells=None, weights=None, nlb=None, lmax=None, is_Dell=False, f_ell=None):
+        super().__init__(nside=nside, bpws=bpws, ells=ells, weights=weights, nlb=nlb, lmax=lmax, is_Dell=False, f_ell=None)
         self.ell_max = self.lmax
 
     def get_window(self, b):


### PR DESCRIPTION
Adding the following features:
- Possibility to easily change the ell binning. Added the following options in the config file in `twopoint_fourier.py`:
        "ell_min": 100,
        "ell_max": 1500,
        "n_ell": 20,
        "ell_spacing": 'log'
- Switched the plotting script to load `summary_statistics_fourier.sacc` instead of `twopoint_data_fourier.sacc` to include errorbars in the plots (the covariance is now in the `summary_statistics_fourier.sacc` file). 
