### PR TITLE
Add weights to metacal selection bias calculation and tidy R_gamma part

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -70,7 +70,7 @@ jobs:
 
     - name: Install executables
       run: |
-        pip install ceci pytest
+        pip install ceci pytest mockmpi
 
     - name: Download test data
       run: |

--- a/examples/2.2i_single_tract_pipeline.yml
+++ b/examples/2.2i_single_tract_pipeline.yml
@@ -3,29 +3,38 @@ launcher:
     name: mini
     interval: 1.0
 
+
+# These site options tell the launcher to use shifter
 site:
-  name: cori-interactive
-  image: joezuntz/txpipe
+    name: cori-interactive
+    image: joezuntz/txpipe
+    volume: ${PWD}:/opt/txpipe
 
-
+# modules and packages to import that have pipeline
+# stages defined in them
 modules: txpipe
 
-# We now also specify parallelization options.
-# By default, things run on one node, with one process, and one thread.
-# But all of these can be changed.
-# Sometimes (like for the TXDiagnosticMaps stage) which uses a lot of memory,
-# we want to use fewer processes but keep them on that one node.
-# Sometimes for slower codes we want to use lots of proceses on multiple nodes
-# and sometimes we have thread-enabled codes that want fewer processes but lots of threads.
+# where to find any modules that are not in this repo,
+# and any other code we need.
+python_paths:
+    - submodules/WLMassMap/python/desc/
+    - submodules/TJPCov
+    - submodules/FlexZPipe
+
 stages:
+    - name: TXJackknifeCenters
+    - name: TXNoiseMaps
     - name: TXSourceSelector
     - name: TXMeanLensSelector
     - name: PZPDFMLZ
-    - name: TXJackknifeCenters
     - name: TXPhotozStack
     - name: TXPhotozPlots
-    - name: TXDiagnosticMaps
+    - name: TXMainMaps
+    - name: TXAuxiliaryMaps
+    - name: TXSimpleMask
+    - name: TXDensityMaps
     - name: TXMapPlots
+    - name: TXTracerMetadata
     - name: TXRandomCat
     - name: TXTwoPoint
     - name: TXNullBlinding
@@ -39,7 +48,6 @@ stages:
 
 output_dir: data/2.2i-single-tract/outputs
 config: examples/config/2.2i_config.yml
-
 
 inputs:
     shear_catalog: /global/projecta/projectdirs/lsst/groups/WL/users/zuntz/data/2.2i-t3828-inputs/shear_catalog.hdf5

--- a/txpipe/test/test_cal.py
+++ b/txpipe/test/test_cal.py
@@ -11,7 +11,8 @@ def select_all_index(data):
     return np.arange(data['mcal_g2'].size)
 
 def select_all_where(data):
-    return np.where(data['mcal_g2'] != 68754337.86543434)
+    # we just want to select everything here too
+    return np.where(data['mcal_g2'] * 0 == 0)
 
 
 

--- a/txpipe/test/test_cal.py
+++ b/txpipe/test/test_cal.py
@@ -165,7 +165,6 @@ def test_mean_shear_weights():
 
     mu, g1, g2, sigma1, sigma2 = b1.collect()
     # Now we have downweighted some of the samples some of these values change.
-    # Update - the calibration changes too, so this test is wrong
     assert np.allclose(mu, [-0.5, 0.5])
     assert np.allclose(g1, [-0.65, 0.35])
     assert np.allclose(g2, [-1.3, 0.7])
@@ -179,5 +178,5 @@ def test_mean_shear_weights():
 if __name__ == '__main__':
     test_metacalibrator_serial()
     test_metacalibrator_parallel()
-    #test_mean_shear()
-    # test_mean_shear_weights()
+    test_mean_shear()
+    test_mean_shear_weights()

--- a/txpipe/test/test_cal.py
+++ b/txpipe/test/test_cal.py
@@ -1,5 +1,94 @@
-from ..utils.calibration_tools import MeanShearInBins
+from ..utils.calibration_tools import MeanShearInBins, ParallelCalibratorMetacal
 import numpy as np
+import mockmpi
+
+
+
+def select_all_bool(data):
+    return np.repeat(True, data['mcal_g2'].size)
+
+def select_all_index(data):
+    np.arange(data['mcal_g2'].size)
+
+def select_all_where(data):
+    return np.where(data['mcal_g2'] != 68754337.86543434)
+
+
+
+def core_metacal(comm):
+    delta_gamma = 0.02
+
+    nproc = 1 if comm is None else comm.size
+
+    N = 10
+    g1_true = np.random.normal(0, 0.1, size=N)
+    g2_true = np.random.normal(0, 0.1, size=N)
+    g_true = np.array([g1_true, g2_true])
+    R_true = np.array([[0.9, 0.1], [0.07, 0.8]])
+    g = R_true @ g_true
+    g_1p = R_true @ (g_true + 0.5*delta_gamma * np.array([+1, 0])[:, np.newaxis])
+    g_1m = R_true @ (g_true + 0.5*delta_gamma * np.array([-1, 0])[:, np.newaxis])
+    g_2p = R_true @ (g_true + 0.5*delta_gamma * np.array([0, +1])[:, np.newaxis])
+    g_2m = R_true @ (g_true + 0.5*delta_gamma * np.array([0, -1])[:, np.newaxis])
+    weight = np.ones(N)
+
+    data = {
+        "mcal_g1": g[0],
+        "mcal_g1_1p": g_1p[0],
+        "mcal_g1_1m": g_1m[0],
+        "mcal_g1_2p": g_2p[0],
+        "mcal_g1_2m": g_2m[0],
+        "mcal_g2": g[1],
+        "mcal_g2_1p": g_1p[1],
+        "mcal_g2_1m": g_1m[1],
+        "mcal_g2_2p": g_2p[1],
+        "mcal_g2_2m": g_2m[1],
+        "weight": weight,
+    }
+
+    # test each type of selector
+    for sel in [select_all_bool, select_all_where, select_all_index]:
+        cal = ParallelCalibratorMetacal(select_all_bool, delta_gamma)
+        cal.add_data(data)
+        R, S, n = cal.collect(comm)
+
+        assert np.allclose(R, R_true)
+        assert np.allclose(S, 0.0)
+        assert n == N * nproc
+
+    # equal non-unit weights - everything should be the same.
+    data["weight"] *= 0.5
+    # test each type of selector
+    for sel in [select_all_bool, select_all_where, select_all_index]:
+        cal = ParallelCalibratorMetacal(select_all_bool, delta_gamma)
+        cal.add_data(data)
+        R, S, n = cal.collect(comm)
+        print("R = ", R)
+
+        assert np.allclose(R, R_true)
+        assert np.allclose(S, 0.0)
+        assert n == N * nproc
+
+    # random weights.  since R is constant this should still be the same
+    data["weight"] = np.random.uniform(0, 1, size=N)
+    # test each type of selector
+    for sel in [select_all_bool, select_all_where, select_all_index]:
+        cal = ParallelCalibratorMetacal(select_all_bool, delta_gamma)
+        cal.add_data(data)
+        R, S, n = cal.collect(comm)
+        print("R = ", R)
+
+        assert np.allclose(R, R_true)
+        assert np.allclose(S, 0.0)
+        assert n == N * nproc
+
+def test_metacalibrator_serial():
+    core_metacal(None)
+
+def test_metacalibrator_parallel():
+    mockmpi.mock_mpiexec(2, core_metacal)
+    mockmpi.mock_mpiexec(10, core_metacal)
+
 
 def test_mean_shear():
     name = "x"
@@ -44,6 +133,10 @@ def test_mean_shear():
     assert np.allclose(sigma1, expected_sigma1)
     assert np.allclose(sigma2, expected_sigma2)
 
+def test_mean_shear_weights():
+    name = "x"
+    limits = [-1., 0., 1.]
+    delta_gamma = 0.02
     # downweighting half of samples
     b1 = MeanShearInBins(name, limits, delta_gamma)
 
@@ -72,6 +165,7 @@ def test_mean_shear():
 
     mu, g1, g2, sigma1, sigma2 = b1.collect()
     # Now we have downweighted some of the samples some of these values change.
+    # Update - the calibration changes too, so this test is wrong
     assert np.allclose(mu, [-0.5, 0.5])
     assert np.allclose(g1, [-0.65, 0.35])
     assert np.allclose(g2, [-1.3, 0.7])
@@ -83,4 +177,7 @@ def test_mean_shear():
 
 
 if __name__ == '__main__':
-    test_mean_shear()
+    test_metacalibrator_serial()
+    test_metacalibrator_parallel()
+    #test_mean_shear()
+    # test_mean_shear_weights()

--- a/txpipe/test/test_cal.py
+++ b/txpipe/test/test_cal.py
@@ -8,7 +8,7 @@ def select_all_bool(data):
     return np.repeat(True, data['mcal_g2'].size)
 
 def select_all_index(data):
-    np.arange(data['mcal_g2'].size)
+    return np.arange(data['mcal_g2'].size)
 
 def select_all_where(data):
     return np.where(data['mcal_g2'] != 68754337.86543434)
@@ -60,7 +60,7 @@ def core_metacal(comm):
     data["weight"] *= 0.5
     # test each type of selector
     for sel in [select_all_bool, select_all_where, select_all_index]:
-        cal = ParallelCalibratorMetacal(select_all_bool, delta_gamma)
+        cal = ParallelCalibratorMetacal(sel, delta_gamma)
         cal.add_data(data)
         R, S, n = cal.collect(comm)
         print("R = ", R)
@@ -73,7 +73,7 @@ def core_metacal(comm):
     data["weight"] = np.random.uniform(0, 1, size=N)
     # test each type of selector
     for sel in [select_all_bool, select_all_where, select_all_index]:
-        cal = ParallelCalibratorMetacal(select_all_bool, delta_gamma)
+        cal = ParallelCalibratorMetacal(sel, delta_gamma)
         cal.add_data(data)
         R, S, n = cal.collect(comm)
         print("R = ", R)

--- a/txpipe/utils/calibration_tools.py
+++ b/txpipe/utils/calibration_tools.py
@@ -279,6 +279,9 @@ class ParallelCalibratorMetacal:
         # collect all the things we need
         if comm is not None:
             count = comm.allreduce(self.count)
+        else:
+            count = self.count
+
 
         # Collect the mean values we need
         _, S = self.sel_bias_means.collect(comm)

--- a/txpipe/utils/calibration_tools.py
+++ b/txpipe/utils/calibration_tools.py
@@ -206,22 +206,7 @@ class ParallelCalibratorMetacal:
         g1 = data_00['mcal_g1']
         g2 = data_00['mcal_g2']
         weight = data_00['weight']
-        # TODO:
-        # Use different weights for different variants!
-
-        # Selector can return several reasonable ways to choose
-        # objects - an np.where result, a boolean mask, or integer indices
-        if isinstance(sel_00, tuple):
-            # tuple returned from np.where
-            n = len(sel_00[0])
-        elif np.issubdtype(sel_00.dtype, np.integer):
-            # integer array
-            n = len(sel_00)
-        elif np.issubdtype(sel_00.dtype, np.bool_):
-            # boolean selection
-            n = sel_00.sum()
-        else:
-            raise ValueError("Selection function passed to Calibrator return type not known")
+        n = g1.size
 
         # Record the count for this chunk, for summation later
         self.count += n
@@ -235,6 +220,8 @@ class ParallelCalibratorMetacal:
         R10 = data_1p['mcal_g2'][sel_00] - data_1m['mcal_g2'][sel_00]
         R11 = data_2p['mcal_g2'][sel_00] - data_2m['mcal_g2'][sel_00]
 
+        # TODO: if there is a weight per variant would we use that here?
+        # Not currently used though.
         self.cal_bias_means.add_data(0, R00, w00)
         self.cal_bias_means.add_data(1, R01, w00)
         self.cal_bias_means.add_data(2, R10, w00)

--- a/txpipe/utils/calibration_tools.py
+++ b/txpipe/utils/calibration_tools.py
@@ -195,7 +195,8 @@ class ParallelCalibratorMetacal:
 
         # These are the selections from this chunk of data
         # that we would make under different shears, the baseline
-        # and all the others
+        # and all the others.  self.selector is a function that the user
+        # supplied in init, not a method
         sel_00 = self.selector(data_00, *args, **kwargs)
         sel_1p = self.selector(data_1p, *args, **kwargs)
         sel_1m = self.selector(data_1m, *args, **kwargs)


### PR DESCRIPTION
Addresses issue #165, adding weights to the selection bias calibration.
At the same time it simplifies the R_gamma (estimator) part of the calibration by using the ParallelMean tool.

The old version was also slightly wrong, since it did the weighted mean of the differences, instead of the diff of the weighted mean, which is not (quite) the same.