### PR TITLE
Stop assuming photometry and shear catalogs are the same size in map code

### DIFF
--- a/examples/2.2i_pipeline.yml
+++ b/examples/2.2i_pipeline.yml
@@ -46,7 +46,10 @@ stages:
     - name: TXMainMaps
       nprocess: 16
       nodes: 2
-    - name: TXAuxiliaryMaps
+    - name: TXAuxiliarySourceMaps
+      nprocess: 16
+      nodes: 2
+    - name: TXAuxiliaryLensMaps
       nprocess: 16
       nodes: 2
     - name: TXSimpleMask

--- a/examples/2.2i_single_tract_pipeline.yml
+++ b/examples/2.2i_single_tract_pipeline.yml
@@ -30,7 +30,8 @@ stages:
     - name: TXPhotozStack
     - name: TXPhotozPlots
     - name: TXMainMaps
-    - name: TXAuxiliaryMaps
+    - name: TXAuxiliarySourceMaps
+    - name: TXAuxiliaryLensMaps
     - name: TXSimpleMask
     - name: TXDensityMaps
     - name: TXMapPlots

--- a/examples/config/2.2i_config.yml
+++ b/examples/config/2.2i_config.yml
@@ -79,10 +79,14 @@ TXMainMaps:
     nside: 1024
     sparse: True
 
-TXAuxiliaryMaps:
+TXAuxiliarySourceMaps:
     chunk_rows:  100000
     sparse:  True
     psf_prefix:  psf_
+
+TXAuxiliaryLensMaps:
+    chunk_rows:  100000
+    sparse:  True
     bright_obj_threshold:  22.0
 
 TXSimpleMask:

--- a/examples/config/cosmodc2_config.yml
+++ b/examples/config/cosmodc2_config.yml
@@ -47,10 +47,14 @@ TXExternalLensMaps:
     pixelization: healpix
 
 
-TXAuxiliaryMaps:
+TXAuxiliarySourceMaps:
     chunk_rows:  100000
     sparse:  True
     psf_prefix:  psf_
+
+TXAuxiliaryLensMaps:
+    chunk_rows:  100000
+    sparse:  True
     bright_obj_threshold:  22.0
 
 TXSimpleMask:

--- a/examples/config/cosmodc2_config_no_shape_noise.yml
+++ b/examples/config/cosmodc2_config_no_shape_noise.yml
@@ -50,10 +50,14 @@ TXExternalLensMaps:
     chunk_rows:  100000
     pixelization: healpix
 
-TXAuxiliaryMaps:
+TXAuxiliarySourceMaps:
     chunk_rows:  100000
     sparse:  True
     psf_prefix:  psf_
+
+TXAuxiliaryLensMaps:
+    chunk_rows:  100000
+    sparse:  True
     bright_obj_threshold:  22.0
 
 TXSimpleMask:

--- a/examples/config/dr1b_config.yml
+++ b/examples/config/dr1b_config.yml
@@ -162,10 +162,11 @@ TXExternalLensMaps:
 
 TXMainMaps: {}
 
-TXAuxiliaryMaps:
+TXAuxiliarySourceMaps:
     flag_exponent_max: 8
-    dilate: True
     psf_prefix: psf_
+
+TXAuxiliaryLensMaps:
     bright_obj_threshold: 22.0 # The magnitude threshold for a object to be counted as bright
     depth_band : i
     snr_threshold: 10.0  # The S/N value to generate maps for (e.g. 5 for 5-sigma depth)

--- a/examples/config/laptop_config.yml
+++ b/examples/config/laptop_config.yml
@@ -211,10 +211,12 @@ TXExternalLensMaps:
 
 TXMainMaps: {}
 
-TXAuxiliaryMaps:
+TXAuxiliarySourceMaps:
     flag_exponent_max: 8
-    dilate: True
     psf_prefix: psf_
+
+TXAuxiliaryLensMaps:
+    flag_exponent_max: 8
     bright_obj_threshold: 22.0 # The magnitude threshold for a object to be counted as bright
     depth_band : i
     snr_threshold: 10.0  # The S/N value to generate maps for (e.g. 5 for 5-sigma depth)

--- a/examples/config/laptop_flat_sky_maps.yml
+++ b/examples/config/laptop_flat_sky_maps.yml
@@ -136,10 +136,12 @@ TXLensMaps:
 
 TXMainMaps: {}
 
-TXAuxiliaryMaps:
+TXAuxiliarySourceMaps:
     flag_exponent_max: 8
-    dilate: True
     psf_prefix: psf_
+
+
+TXAuxiliaryLensMaps:
     bright_obj_threshold: 22.0 # The magnitude threshold for a object to be counted as bright
     depth_band : i
     snr_threshold: 10.0  # The S/N value to generate maps for (e.g. 5 for 5-sigma depth)

--- a/examples/config/laptop_lensfit_config.yml
+++ b/examples/config/laptop_lensfit_config.yml
@@ -183,10 +183,11 @@ TXLensMaps: {}
 
 TXMainMaps: {}
 
-TXAuxiliaryMaps:
+TXAuxiliarySourceMaps:
     flag_exponent_max: 1
-    dilate: True
     psf_prefix: psf_
+
+TXAuxiliaryLensMaps:
     bright_obj_threshold: 22.0 # The magnitude threshold for a object to be counted as bright
     depth_band : i
     snr_threshold: 10.0  # The S/N value to generate maps for (e.g. 5 for 5-sigma depth)

--- a/examples/config/skysim5000_config.yml
+++ b/examples/config/skysim5000_config.yml
@@ -42,9 +42,12 @@ TXExternalLensMaps:
     pixelization: healpix
 
 
-TXAuxiliaryMaps:
+TXAuxiliarySourceMaps:
     sparse:  True
     psf_prefix:  psf_
+
+TXAuxiliaryLensMaps:
+    sparse:  True
     bright_obj_threshold:  22.0
 
 TXSimpleMask:

--- a/examples/cosmodc2_pipeline.yml
+++ b/examples/cosmodc2_pipeline.yml
@@ -28,7 +28,9 @@ stages:
     - name: TXJackknifeCenters
     - name: TXMainMaps
       nprocess: 8
-    - name: TXAuxiliaryMaps
+    - name: TXAuxiliarySourceMaps
+      nprocess: 8
+    - name: TXAuxiliaryLensMaps
       nprocess: 8
     - name: TXDensityMaps
     - name: TXNoiseMaps

--- a/examples/cosmodc2_redmagic_pipeline.yml
+++ b/examples/cosmodc2_redmagic_pipeline.yml
@@ -35,7 +35,11 @@ stages:
       threads_per_process: 1
       nodes: 3
     - name: TXExternalLensMaps
-    - name: TXAuxiliaryMaps
+    - name: TXAuxiliarySourceMaps
+      nprocess: 8
+      threads_per_process: 1
+      nodes: 1
+    - name: TXAuxiliaryLensMaps
       nprocess: 8
       threads_per_process: 1
       nodes: 1

--- a/examples/cosmodc2_redmagic_pipeline_no_shape_noise.yml
+++ b/examples/cosmodc2_redmagic_pipeline_no_shape_noise.yml
@@ -35,7 +35,11 @@ stages:
       threads_per_process: 1
       nodes: 3
     - name: TXExternalLensMaps
-    - name: TXAuxiliaryMaps
+    - name: TXAuxiliarySourceMaps
+      nprocess: 16
+      threads_per_process: 1
+      nodes: 2
+    - name: TXAuxiliaryLensMaps
       nprocess: 16
       threads_per_process: 1
       nodes: 2

--- a/examples/cosmodc2_redmagic_pipeline_no_shape_noise_full.yml
+++ b/examples/cosmodc2_redmagic_pipeline_no_shape_noise_full.yml
@@ -33,7 +33,11 @@ stages:
       threads_per_process: 1
       nodes: 2
     - name: TXExternalLensMaps
-    - name: TXAuxiliaryMaps
+    - name: TXAuxiliarySourceMaps
+      nprocess: 16
+      threads_per_process: 1
+      nodes: 2
+    - name: TXAuxiliaryLensMaps
       nprocess: 16
       threads_per_process: 1
       nodes: 2

--- a/examples/dr1b_pipeline.yml
+++ b/examples/dr1b_pipeline.yml
@@ -11,7 +11,8 @@ stages:
       threads_per_process: 16
     - name: TXJackknifeCenters
     - name: TXMainMaps
-    - name: TXAuxiliaryMaps
+    - name: TXAuxiliarySourceMaps
+    - name: TXAuxiliaryLensMaps
     - name: TXDensityMaps
     - name: TXNoiseMaps
     - name: TXSimpleMask

--- a/examples/laptop_complete_pipeline.yml
+++ b/examples/laptop_complete_pipeline.yml
@@ -5,11 +5,14 @@ stages:
     - name: TXLensCatalogSplitter
     - name: TXStarCatalogSplitter
     - name: TXTruthLensSelector
-    - name: PZRailTrain
-    - name: PZRailEstimate
+    - name: PZRailTrainSource
+      threads_per_process: 2
+    - name: PZRailEstimateSource # Compute p(z) values for the source sample
+    - name: PZRailEstimateLensFromSource   # Copy the p(z) values from the source to lens values
     - name: TXPhotozStack
     - name: TXMainMaps
-    - name: TXAuxiliaryMaps
+    - name: TXAuxiliarySourceMaps
+    - name: TXAuxiliaryLensMaps
     - name: TXSimpleMask
     - name: TXDensityMaps
     - name: TXMapPlots

--- a/examples/laptop_lensfit_pipeline.yml
+++ b/examples/laptop_lensfit_pipeline.yml
@@ -12,7 +12,8 @@ stages:
     - name: TXPhotozSourceStack
     - name: TXPhotozLensStack
     - name: TXMainMaps
-    - name: TXAuxiliaryMaps
+    - name: TXAuxiliarySourceMaps
+    - name: TXAuxiliaryLensMaps
     - name: TXSimpleMask
     - name: TXDensityMaps
     - name: TXMapPlots

--- a/examples/laptop_pipeline.yml
+++ b/examples/laptop_pipeline.yml
@@ -21,7 +21,8 @@ stages:
     - name: TXPhotozSourceStack  # Stack p(z) into n(z)
     - name: TXPhotozLensStack    # Stack p(z) into n(z)
     - name: TXMainMaps           # make source g1, g2 and lens n_gal maps
-    - name: TXAuxiliaryMaps      # make PSF, depth, flag, and other maps
+    - name: TXAuxiliarySourceMaps  # make PSF and flag maps
+    - name: TXAuxiliaryLensMaps    # make depth and bright object maps
     - name: TXSimpleMask         # combine maps to make a simple mask
     - name: TXDensityMaps        # turn mask and ngal maps into overdensity maps
     - name: TXMapPlots           # make pictures of all the maps

--- a/examples/laptop_redmagic_complete_pipeline.yml
+++ b/examples/laptop_redmagic_complete_pipeline.yml
@@ -7,7 +7,8 @@ stages:
     - name: TXIngestRedmagic
     - name: TXSourceMaps
     - name: TXExternalLensMaps
-    - name: TXAuxiliaryMaps
+    - name: TXAuxiliarySourceMaps
+    - name: TXAuxiliaryLensMaps
     - name: TXSimpleMask
     - name: TXDensityMaps
     - name: TXMapPlots

--- a/examples/laptop_redmagic_pipeline.yml
+++ b/examples/laptop_redmagic_pipeline.yml
@@ -10,7 +10,8 @@ stages:
     - name: TXTracerMetadata
     - name: TXSourceMaps
     - name: TXExternalLensMaps
-    - name: TXAuxiliaryMaps
+    - name: TXAuxiliarySourceMaps
+    - name: TXAuxiliaryLensMaps
     - name: TXSimpleMask
     - name: TXDensityMaps
     - name: TXMapPlots

--- a/examples/skysim5000_pipeline.yml
+++ b/examples/skysim5000_pipeline.yml
@@ -36,7 +36,10 @@ stages:
     - name: TXMainMaps
       nodes: 8
       nprocess: 64
-    - name: TXAuxiliaryMaps
+    - name: TXAuxiliarySourceMaps
+      nodes: 2
+      nprocess: 16
+    - name: TXAuxiliaryLensMaps
       nodes: 2
       nprocess: 16
     - name: TXTwoPointTheoryReal # compute theory using CCL to save in sacc file and plot later

--- a/txpipe/__init__.py
+++ b/txpipe/__init__.py
@@ -23,7 +23,7 @@ from .psf_diagnostics import TXPSFDiagnostics, TXRoweStatistics
 from .noise_maps import TXNoiseMaps
 from .ingest_redmagic import TXIngestRedmagic
 from .maps import TXMainMaps
-from .auxiliary_maps import TXAuxiliaryMaps
+from .auxiliary_maps import TXAuxiliarySourceMaps, TXAuxiliaryLensMaps
 from .map_plots import TXMapPlots
 from .masks import TXSimpleMask
 from .metadata import TXTracerMetadata

--- a/txpipe/auxiliary_maps.py
+++ b/txpipe/auxiliary_maps.py
@@ -7,8 +7,8 @@ from .utils import choose_pixelization
 from .utils.calibration_tools import read_shear_catalog_type
 
 
-class TXAuxiliaryMaps(TXBaseMaps):
-    name = "TXAuxiliaryMaps"
+class TXAuxiliarySourceMaps(TXBaseMaps):
+    name = "TXAuxiliarySourceMaps"
     """
     This class generates:
         - depth maps
@@ -17,13 +17,12 @@ class TXAuxiliaryMaps(TXBaseMaps):
         - flag maps
     """
     inputs = [
-        ("photometry_catalog", HDFFile),  # for mags etc
         ("shear_catalog", ShearCatalog),  # for psfs
         ("shear_tomography_catalog", HDFFile),  # for per-bin psf maps
         ("source_maps", MapsFile),  # we copy the pixel scheme from here
     ]
     outputs = [
-        ("aux_maps", MapsFile),
+        ("aux_source_maps", MapsFile),
     ]
 
     config_options = {
@@ -31,10 +30,6 @@ class TXAuxiliaryMaps(TXBaseMaps):
         "sparse": True,
         "flag_exponent_max": 8,  # flag bits go up to 2**8 by default
         "psf_prefix": "psf_",  # prefix name for columns
-        "bright_obj_threshold": 22.0,  # The magnitude threshold for a object to be counted as bright
-        "depth_band": "i",  # Make depth maps for this band
-        "snr_threshold": 10.0,  # The S/N value to generate maps for (e.g. 5 for 5-sigma depth)
-        "snr_delta": 1.0,  # The range threshold +/- delta is used for finding objects at the boundary
     }
     # instead of reading from config we match the basic maps
     def choose_pixel_scheme(self):
@@ -57,32 +52,14 @@ class TXAuxiliaryMaps(TXBaseMaps):
             pixel_scheme, [], source_bins, do_lens=False, sparse=self.config["sparse"]
         )
 
-        # for estimating depth per lens-bin
-        depth_mapper = DepthMapperDR1(
-            pixel_scheme,
-            self.config["snr_threshold"],
-            self.config["snr_delta"],
-            sparse=self.config["sparse"],
-            comm=self.comm,
-        )
-
-        # for mapping bright star fractions, for masks
-        brobj_mapper = BrightObjectMapper(
-            pixel_scheme,
-            self.config["bright_obj_threshold"],
-            sparse=self.config["sparse"],
-            comm=self.comm,
-        )
-
         # for mapping the density of flagged objects
         flag_mapper = FlagMapper(
             pixel_scheme, self.config["flag_exponent_max"], sparse=self.config["sparse"]
         )
 
-        return psf_mapper, depth_mapper, brobj_mapper, flag_mapper
+        return psf_mapper, flag_mapper
 
     def data_iterator(self):
-        band = self.config["depth_band"]
         psf_prefix = self.config["psf_prefix"]
         shear_catalog_type = read_shear_catalog_type(self)
 
@@ -92,14 +69,12 @@ class TXAuxiliaryMaps(TXBaseMaps):
         else:
             shear_cols = [f"{psf_prefix}g1", f"{psf_prefix}g2", "flags", "weight"]
 
+        shear_cols += ["ra", "dec"]
+
         # See maps.py for an explanation of this
         return self.combined_iterators(
             self.config["chunk_rows"],
             # first file
-            "photometry_catalog",
-            "photometry",
-            ["ra", "dec", "extendedness", f"snr_{band}", f"mag_{band}"],
-            # next file
             "shear_catalog",
             "shear",
             shear_cols,
@@ -110,26 +85,12 @@ class TXAuxiliaryMaps(TXBaseMaps):
         )
 
     def accumulate_maps(self, pixel_scheme, data, mappers):
-        psf_mapper, depth_mapper, brobj_mapper, flag_mapper = mappers
+        psf_mapper, flag_mapper = mappers
 
-        band = self.config["depth_band"]
         psf_prefix = self.config["psf_prefix"]
 
         # Our different mappers want different data columns.
         # We pull out the bits they need and give them just those.
-        brobj_data = {
-            "mag": data[f"mag_{band}"],
-            "extendedness": data["extendedness"],
-            "ra": data["ra"],
-            "dec": data["dec"],
-        }
-
-        depth_data = {
-            "mag": data[f"mag_{band}"],
-            "snr": data[f"snr_{band}"],
-            "ra": data["ra"],
-            "dec": data["dec"],
-        }
 
         psf_data = {
             "g1": data[f"{psf_prefix}g1"],
@@ -152,19 +113,13 @@ class TXAuxiliaryMaps(TXBaseMaps):
             flag_data["flags"] = data["flags"]
 
         psf_mapper.add_data(psf_data)
-        depth_mapper.add_data(depth_data)
-        brobj_mapper.add_data(brobj_data)
         flag_mapper.add_data(flag_data)
 
     def finalize_mappers(self, pixel_scheme, mappers):
-        psf_mapper, depth_mapper, brobj_mapper, flag_mapper = mappers
+        psf_mapper, flag_mapper = mappers
 
         # Four different mappers
         pix, _, _, g1, g2, var_g1, var_g2, weight = psf_mapper.finalize(self.comm)
-        depth_pix, depth_count, depth, depth_var = depth_mapper.finalize(self.comm)
-        brobj_pix, brobj_count, brobj_mag, brobj_mag_var = brobj_mapper.finalize(
-            self.comm
-        )
         flag_pixs, flag_maps = flag_mapper.finalize(self.comm)
 
         # Collect all the maps
@@ -175,24 +130,16 @@ class TXAuxiliaryMaps(TXBaseMaps):
 
         # Save PSF maps
         for b in psf_mapper.source_bins:
-            maps["aux_maps", f"psf/g1_{b}"] = (pix, g1[b])
-            maps["aux_maps", f"psf/g2_{b}"] = (pix, g1[b])
-            maps["aux_maps", f"psf/var_g2_{b}"] = (pix, var_g1[b])
-            maps["aux_maps", f"psf/var_g2_{b}"] = (pix, var_g1[b])
-            maps["aux_maps", f"psf/lensing_weight_{b}"] = (pix, weight[b])
-
-        # Save depth maps
-        maps["aux_maps", "depth/depth"] = (depth_pix, depth)
-        maps["aux_maps", "depth/depth_count"] = (depth_pix, depth_count)
-        maps["aux_maps", "depth/depth_var"] = (depth_pix, depth_var)
-
-        # Save bright object counts
-        maps["aux_maps", "bright_objects/count"] = (brobj_pix, brobj_count)
+            maps["aux_source_maps", f"psf/g1_{b}"] = (pix, g1[b])
+            maps["aux_source_maps", f"psf/g2_{b}"] = (pix, g1[b])
+            maps["aux_source_maps", f"psf/var_g2_{b}"] = (pix, var_g1[b])
+            maps["aux_source_maps", f"psf/var_g2_{b}"] = (pix, var_g1[b])
+            maps["aux_source_maps", f"psf/lensing_weight_{b}"] = (pix, weight[b])
 
         # Save flag maps
         for i, (p, m) in enumerate(zip(flag_pixs, flag_maps)):
             f = 2 ** i
-            maps["aux_maps", f"flags/flag_{f}"] = (p, m)
+            maps["aux_source_maps", f"flags/flag_{f}"] = (p, m)
             # also print out some stats
             t = m.sum()
             print(f"Map shows total {t} objects with flag {f}")
@@ -200,32 +147,112 @@ class TXAuxiliaryMaps(TXBaseMaps):
         return maps
 
 
-class TXStandaloneAuxiliaryMaps(TXAuxiliaryMaps):
-    name = "TXStandaloneAuxiliaryMaps"
+
+class TXAuxiliaryLensMaps(TXBaseMaps):
+    name = "TXAuxiliaryLensMaps"
     """
     This class generates:
         - depth maps
         - psf maps
         - bright object maps
         - flag maps
-
-    but unlike its parent class does not require an input
-    source map to choose a pixelization scheme; instead
-    you specify one in the configuration.
     """
     inputs = [
         ("photometry_catalog", HDFFile),  # for mags etc
-        ("shear_catalog", ShearCatalog),  # for psfs
-        ("shear_tomography_catalog", HDFFile),  # for per-bin psf maps
+        ("lens_maps", MapsFile),  # we copy the pixel scheme from here
     ]
     outputs = [
-        ("aux_maps", MapsFile),
+        ("aux_lens_maps", MapsFile),
     ]
 
     config_options = {
-        ** TXAuxiliaryMaps.config_options,
-        ** map_config_options,
+        "chunk_rows": 100_000,
+        "sparse": True,
+        "bright_obj_threshold": 22.0,  # The magnitude threshold for a object to be counted as bright
+        "depth_band": "i",  # Make depth maps for this band
+        "snr_threshold": 10.0,  # The S/N value to generate maps for (e.g. 5 for 5-sigma depth)
+        "snr_delta": 1.0,  # The range threshold +/- delta is used for finding objects at the boundary
     }
     # instead of reading from config we match the basic maps
     def choose_pixel_scheme(self):
-        return choose_pixelization(**self.config)
+        with self.open_input("lens_maps", wrapper=True) as maps_file:
+            pix_info = dict(maps_file.file["maps"].attrs)
+
+        return choose_pixelization(**pix_info)
+
+    def prepare_mappers(self, pixel_scheme):
+        # We make a suite of mappers here.
+
+        # for estimating depth per lens-bin
+        depth_mapper = DepthMapperDR1(
+            pixel_scheme,
+            self.config["snr_threshold"],
+            self.config["snr_delta"],
+            sparse=self.config["sparse"],
+            comm=self.comm,
+        )
+
+        # for mapping bright star fractions, for masks
+        brobj_mapper = BrightObjectMapper(
+            pixel_scheme,
+            self.config["bright_obj_threshold"],
+            sparse=self.config["sparse"],
+            comm=self.comm,
+        )
+
+        return depth_mapper, brobj_mapper
+
+    def data_iterator(self):
+        band = self.config["depth_band"]
+        cols = ["ra", "dec", "extendedness", f"snr_{band}", f"mag_{band}"]
+        return self.iterate_hdf("photometry_catalog", "photometry", cols, self.config["chunk_rows"])
+
+
+    def accumulate_maps(self, pixel_scheme, data, mappers):
+        depth_mapper, brobj_mapper = mappers
+        band = self.config["depth_band"]
+
+        # Our different mappers want different data columns.
+        # We pull out the bits they need and give them just those.
+        brobj_data = {
+            "mag": data[f"mag_{band}"],
+            "extendedness": data["extendedness"],
+            "ra": data["ra"],
+            "dec": data["dec"],
+        }
+
+        depth_data = {
+            "mag": data[f"mag_{band}"],
+            "snr": data[f"snr_{band}"],
+            "ra": data["ra"],
+            "dec": data["dec"],
+        }
+
+        depth_mapper.add_data(depth_data)
+        brobj_mapper.add_data(brobj_data)
+
+    def finalize_mappers(self, pixel_scheme, mappers):
+        depth_mapper, brobj_mapper = mappers
+
+        # Four different mappers
+        depth_pix, depth_count, depth, depth_var = depth_mapper.finalize(self.comm)
+        brobj_pix, brobj_count, brobj_mag, brobj_mag_var = brobj_mapper.finalize(
+            self.comm
+        )
+
+        # Collect all the maps
+        maps = {}
+
+        if self.rank != 0:
+            return maps
+
+        # Save depth maps
+        maps["aux_lens_maps", "depth/depth"] = (depth_pix, depth)
+        maps["aux_lens_maps", "depth/depth_count"] = (depth_pix, depth_count)
+        maps["aux_lens_maps", "depth/depth_var"] = (depth_pix, depth_var)
+
+        # Save bright object counts
+        maps["aux_lens_maps", "bright_objects/count"] = (brobj_pix, brobj_count)
+
+
+        return maps

--- a/txpipe/diagnostics.py
+++ b/txpipe/diagnostics.py
@@ -81,27 +81,23 @@ class TXDiagnosticPlots(PipelineStage):
         lens_tomo_cols = ['lens_bin']
 
         if self.config['shear_catalog_type']=='metacal':
-            it = self.combined_iterators(chunk_rows,
-                                         'shear_catalog', 'shear', shear_cols,
-                                         'photometry_catalog', 'photometry', photo_cols,
-                                         'shear_tomography_catalog','tomography',shear_tomo_cols,
-                                         'shear_tomography_catalog','metacal_response', ['R_gamma'],
-                                         'lens_tomography_catalog','tomography',lens_tomo_cols)
+            response_group = 'metacal_response'
+            response_cols = ['R_gamma']
         elif self.config['shear_catalog_type']=='lensfit':
-            it = self.combined_iterators(chunk_rows,
-                                         'shear_catalog', 'shear', shear_cols,
-                                         'photometry_catalog', 'photometry', photo_cols,
-                                         'shear_tomography_catalog','tomography',shear_tomo_cols,
-                                         'shear_tomography_catalog','response',['K'],
-                                         'lens_tomography_catalog','tomography',lens_tomo_cols)
+            response_cols = ['K']
+            response_group = 'response'
         else:
-            it = self.combined_iterators(chunk_rows,
-                                         'shear_catalog', 'shear', shear_cols,
-                                         'photometry_catalog', 'photometry', photo_cols,
-                                         'shear_tomography_catalog','tomography',shear_tomo_cols,
-                                         'shear_tomography_catalog','response',['R'],
-                                         'lens_tomography_catalog','tomography',lens_tomo_cols)
+            response_cols = ['R']
+            response_group = 'response'
 
+        it = self.combined_iterators(
+            chunk_rows,
+            'photometry_catalog', 'photometry', photo_cols,
+            'shear_catalog', 'shear', shear_cols,
+            'shear_tomography_catalog','tomography',shear_tomo_cols,
+            'shear_tomography_catalog', response_group, response_cols,
+            'lens_tomography_catalog','tomography',lens_tomo_cols
+        )
 
         # Now loop through each chunk of input data, one at a time.
         # Each time we get a new segment of data, which goes to all the plotters

--- a/txpipe/diagnostics.py
+++ b/txpipe/diagnostics.py
@@ -76,9 +76,6 @@ class TXDiagnosticPlots(PipelineStage):
         photo_cols = ['mag_u', 'mag_g', 'mag_r', 'mag_i', 'mag_z', 'mag_y']
         shear_tomo_cols = ['source_bin']
         lens_tomo_cols = ['lens_bin']
-        photo_cols = ['mag_u', 'mag_g', 'mag_r', 'mag_i', 'mag_z', 'mag_y']
-        shear_tomo_cols = ['source_bin']
-        lens_tomo_cols = ['lens_bin']
 
         if self.config['shear_catalog_type']=='metacal':
             response_group = 'metacal_response'

--- a/txpipe/map_plots.py
+++ b/txpipe/map_plots.py
@@ -14,7 +14,8 @@ class TXMapPlots(PipelineStage):
         ("lens_maps", MapsFile),
         ("density_maps", MapsFile),
         ("mask", MapsFile),
-        ("aux_maps", MapsFile),
+        ("aux_source_maps", MapsFile),
+        ("aux_lens_maps", MapsFile),
     ]
 
     outputs = [
@@ -40,30 +41,21 @@ class TXMapPlots(PipelineStage):
 
         # Plot from each file separately, just
         # to organize this file a bit
-        self.aux_plots()
+        self.aux_source_plots()
+        self.aux_lens_plots()
         self.source_plots()
         self.lens_plots()
         self.mask_plots()
 
-    def aux_plots(self):
+    def aux_source_plots(self):
         import matplotlib.pyplot as plt
 
-        m = self.open_input("aux_maps", wrapper=True)
+        m = self.open_input("aux_source_maps", wrapper=True)
 
         # Get these two config options from the maps where
         # they were originally saved
         nbin_source = m.file["maps"].attrs["nbin_source"]
         flag_max = m.file["maps"].attrs["flag_exponent_max"]
-
-        # Depth plots
-        fig = self.open_output("depth_map", wrapper=True, figsize=(5, 5))
-        m.plot("depth/depth", view=self.config["projection"])
-        fig.close()
-
-        # Bright objects
-        fig = self.open_output("bright_object_map", wrapper=True, figsize=(5, 5))
-        m.plot("bright_objects/count", view=self.config["projection"])
-        fig.close()
 
         # Flag count plots - flags are assumed to be bitsets, so
         # we make maps of 1, 2, 4, 8, 16, ...
@@ -82,6 +74,21 @@ class TXMapPlots(PipelineStage):
             m.plot(f"psf/g1_{i}", view=self.config["projection"])
             plt.sca(axes[1, i])
             m.plot(f"psf/g2_{i}", view=self.config["projection"])
+        fig.close()
+
+    def aux_lens_plots(self):
+        import matplotlib.pyplot as plt
+
+        m = self.open_input("aux_lens_maps", wrapper=True)
+
+        # Depth plots
+        fig = self.open_output("depth_map", wrapper=True, figsize=(5, 5))
+        m.plot("depth/depth", view=self.config["projection"])
+        fig.close()
+
+        # Bright objects
+        fig = self.open_output("bright_object_map", wrapper=True, figsize=(5, 5))
+        m.plot("bright_objects/count", view=self.config["projection"])
         fig.close()
 
     def source_plots(self):

--- a/txpipe/maps.py
+++ b/txpipe/maps.py
@@ -439,6 +439,9 @@ class TXMainMaps(TXSourceMaps, TXLensMaps):
     Combined source and photometric lens maps, from the
     same photometry catalog.  Same as running TXSourceMaps
     and then TXLensMaps but faster as we only do the I/O once.
+
+    Only works if the source and lens catalogs are the same;
+    otherwise use TXSourceMaps and TXLensMaps separately.
     """
 
     name = "TXMainMaps"
@@ -460,6 +463,17 @@ class TXMainMaps(TXSourceMaps, TXLensMaps):
         # This is just the combination of
         # the source and lens map columns
         print("TODO: no lens weights here")
+
+        with self.open_input("photometry_catalog") as f:
+            sz1 = f['photometry/ra'].size
+        with self.open_input("shear_catalog") as f:
+            sz2 = f['shear/ra'].size
+
+        if sz1 != sz2:
+            raise ValueError("Shear and photometry catalogs in TXMainMaps are "
+                             "different sizes. To use separate source and lens "
+                             "samples use TXSourceMaps and TXLensMaps separately."
+                             )
 
         # metacal, lensfit, etc.
         shear_catalog_type = read_shear_catalog_type(self)

--- a/txpipe/masks.py
+++ b/txpipe/masks.py
@@ -7,7 +7,7 @@ from .data_types import MapsFile
 class TXSimpleMask(PipelineStage):
     name = "TXSimpleMask"
     # make a mask from the auxiliary maps
-    inputs = [("aux_maps", MapsFile)]
+    inputs = [("aux_lens_maps", MapsFile)]
     outputs = [("mask", MapsFile)]
     config_options = {
         "depth_cut": 23.5,
@@ -17,7 +17,7 @@ class TXSimpleMask(PipelineStage):
     def run(self):
         import healpy
 
-        with self.open_input("aux_maps", wrapper=True) as f:
+        with self.open_input("aux_lens_maps", wrapper=True) as f:
             metadata = dict(f.file["maps"].attrs)
             bright_obj = f.read_map("bright_objects/count")
             depth = f.read_map("depth/depth")

--- a/txpipe/noise_maps.py
+++ b/txpipe/noise_maps.py
@@ -12,6 +12,9 @@ class TXNoiseMaps(PipelineStage):
     Generate a suite of random noise maps by randomly
     rotating individual galaxy measurements.
 
+    Only works if the source and lens catalogs are the same lengths.
+    Otherwise use TXSourceNoiseMaps and TXLensNoiseMaps below
+
     """
     # TODO rewrite this as a TXBaseMaps subclass
     # like the two below    
@@ -221,9 +224,17 @@ class TXNoiseMaps(PipelineStage):
             nbin_lens = f.file['maps'].attrs['nbin_lens']
             ngal_maps = [f.read_map(f'ngal_{b}') for b in range(nbin_lens)]
 
-        with self.open_input('shear_tomography_catalog', wrapper=True) as f:
-            nbin_source = f.file['tomography'].attrs['nbin_source']
+        with self.open_input('shear_tomography_catalog') as f:
+            nbin_source = f['tomography'].attrs['nbin_source']
+            sz1 = f['tomography/source_bin'].size
 
+        with self.open_input('lens_tomography_catalog') as f:
+            sz2 = f['tomography/lens_bin'].size
+
+        if sz1 != sz2:
+            raise ValueError("Lens and source catalogs are different sizes in "
+                             "TXNoiseMaps. In this case run TXSourceNoiseMaps "
+                             "and TXLensNoiseMaps separately.")
 
         return nbin_source, nbin_lens, ngal_maps, mask, map_info
 

--- a/txpipe/random_cats.py
+++ b/txpipe/random_cats.py
@@ -7,7 +7,7 @@ import numpy as np
 class TXRandomCat(PipelineStage):
     name='TXRandomCat'
     inputs = [
-        ('aux_maps', MapsFile),
+        ('aux_lens_maps', MapsFile),
         ('lens_photoz_stack', HDFFile),
     ]
     outputs = [
@@ -26,7 +26,7 @@ class TXRandomCat(PipelineStage):
         import healpy
         from . import randoms
         # Load the input depth map
-        with self.open_input('aux_maps', wrapper=True) as maps_file:
+        with self.open_input('aux_lens_maps', wrapper=True) as maps_file:
             depth = maps_file.read_map('depth/depth')
             info = maps_file.read_map_info('depth/depth')
             nside = info['nside']


### PR DESCRIPTION
The previous implementation of the mapping code assumed in some places that the photometry and shear catalogs were the same length; this won't be the case for metadetect and other catalogs.

The main map-making code already had optional separate lens and source mappers.

This PR:
- errors with a useful message if the user tries to use a combined mapper when the lengths are different
- split the auxiliary maps into aux_source_maps (PSF and flag maps) and aux_lens_maps (bright object and depth maps), with a stage to make each
- updates the downstream uses of the aux maps to use the right one(s)
- updates yaml pipeline and config files

Most of the changes are to configuration files and pipeline yaml, switching them to use the new stages; if you're reviewing this they don't really need to be gone through carefully!