### PR TITLE
For unknown files in TXTwoPoint make cache dir based on creation time and absolute path

### DIFF
--- a/txpipe/twopoint.py
+++ b/txpipe/twopoint.py
@@ -8,7 +8,6 @@ import collections
 import sys
 import os
 import pathlib
-import warnings
 from time import perf_counter
 import gc
 


### PR DESCRIPTION
Fixes problem Judit sees with clashing cache dirs