### PR TITLE
TJPCov NaMaster covariance parallelized

### DIFF
--- a/txpipe/covariance.py
+++ b/txpipe/covariance.py
@@ -650,6 +650,8 @@ class TXFourierTJPCovariance(PipelineStage):
         # there is one of the workspaces missing). For generality, I will pass
         # it.
         tjp_config['binning_info'] = self.recover_NmtBin(cl_sacc)
+        # MPI
+        tjp_config['use_mpi'] = True if self.comm is not None else False
         calculator = tjpcov.main.CovarianceCalculator({"tjpcov":tjp_config})
 
         cache = {'workspaces': workspaces}

--- a/txpipe/covariance.py
+++ b/txpipe/covariance.py
@@ -645,13 +645,16 @@ class TXFourierTJPCovariance(PipelineStage):
         # Load NmtBin used for the Cells
         workspaces = self.get_workspaces_dict(cl_sacc, masks_names)
 
+        # MPI
+        if self.comm:
+            self.comm.Barrier()
+            tjp_config['use_mpi'] = True
+
         # Run TJPCov
         # I shouldn't need to pass the binnning (unless the cache is not set or
         # there is one of the workspaces missing). For generality, I will pass
         # it.
         tjp_config['binning_info'] = self.recover_NmtBin(cl_sacc)
-        # MPI
-        tjp_config['use_mpi'] = True if self.comm is not None else False
         calculator = tjpcov.main.CovarianceCalculator({"tjpcov":tjp_config})
 
         cache = {'workspaces': workspaces}


### PR DESCRIPTION
Allow computing the NaMaster covariance's blocks in parallel. It will be fully functional after merging this PR: https://github.com/LSSTDESC/TJPCov/pull/29 