### PR TITLE
Update HSC branch to use already computed noise in TJPCov

### DIFF
--- a/txpipe/covariance.py
+++ b/txpipe/covariance.py
@@ -679,9 +679,9 @@ class TXFourierTJPCovariance(PipelineStage):
         for tr in cl_sacc.tracers.keys():
             # TODO: This could be made more general
             if 'source' in tr:
-                dtype = sacc.standard_types.galaxy_density_cl
-            elif 'lens' in tr:
                 dtype = sacc.standard_types.galaxy_shear_cl_ee
+            elif 'lens' in tr:
+                dtype = sacc.standard_types.galaxy_density_cl
             else:
                 raise ValueError('dtype could not be identified for tracer ' +
                                  f'{tr}')

--- a/txpipe/covariance.py
+++ b/txpipe/covariance.py
@@ -5,6 +5,7 @@ import numpy as np
 import warnings
 import os
 import pickle
+import sacc
 
 # require TJPCov to be in PYTHONPATH
 d2r=np.pi/180
@@ -658,7 +659,9 @@ class TXFourierTJPCovariance(PipelineStage):
         calculator = tjpcov.main.CovarianceCalculator({"tjpcov":tjp_config})
 
         cache = {'workspaces': workspaces}
-        covmat = calculator.get_all_cov_nmt(cache=cache)
+        tracer_nlcp= self.get_tracer_noise_from_sacc(cl_sacc)
+        covmat = calculator.get_all_cov_nmt(cache=cache,
+                                            tracer_noise_coupled=tracer_nlcp)
 
         # Write the sacc file with the covariance
         if self.rank == 0:
@@ -666,6 +669,30 @@ class TXFourierTJPCovariance(PipelineStage):
             output_filename = self.get_output('summary_statistics_fourier')
             cl_sacc.save_fits(output_filename, overwrite=True)
             print("Saved power spectra with its Gaussian covariance")
+
+    def get_tracer_noise_from_sacc(self, cl_sacc):
+        # This could be done inside TJPCov:
+        # https://github.com/LSSTDESC/TJPCov/issues/31
+        tags = cl_sacc.data[0].tags
+
+        tracer_noise = {}
+        for tr in cl_sacc.tracers.keys():
+            # TODO: This could be made more general
+            if 'source' in tr:
+                dtype = sacc.standard_types.galaxy_density_cl
+            elif 'lens' in tr:
+                dtype = sacc.standard_types.galaxy_shear_cl_ee
+            else:
+                raise ValueError('dtype could not be identified for tracer ' +
+                                 f'{tr}')
+            nl = cl_sacc.get_tag('nl_cp', data_type=dtype, tracers=(tr, tr))
+
+            # TJPCov assumes a white coupled noise and requires a float or int
+            # to be passed. Use the last entry element since nl = 0 for ell=1,2
+            # in the case of shear
+            tracer_noise[tr] = nl[-1]
+
+        return tracer_noise
 
     def get_workspaces_dict(self, cl_sacc, masks_names):
         # Based on txpipe/twopoint_fourier.py

--- a/txpipe/covariance.py
+++ b/txpipe/covariance.py
@@ -744,13 +744,22 @@ class TXFourierTJPCovariance(PipelineStage):
         # TODO: Move this to txpipe/utils/nmt_utils.py
         from .utils.nmt_utils import MyNmtBin
 
-        ell_min = cl_sacc.metadata['binning/ell_min']
-        ell_max = cl_sacc.metadata['binning/ell_max']
-        ell_spacing = cl_sacc.metadata['binning/ell_spacing']
-        n_ell = cl_sacc.metadata['binning/n_ell']
+        if 'binning/ell_edges' in cl_sacc.metadata:
+            s = cl_sacc.metadata['binning/ell_edges'].strip('[]')
+            s=s.replace(' ', '')
+            s=s.split(',')
+            ell_edges = [int(i) for i in s]
+            print(ell_edges)
+            ell_bins = MyNmtBin.from_edges(ell_edges[:-1], ell_edges[1:],
+                                           is_Dell=False)
+        else:
+            ell_min = cl_sacc.metadata['binning/ell_min']
+            ell_max = cl_sacc.metadata['binning/ell_max']
+            ell_spacing = cl_sacc.metadata['binning/ell_spacing']
+            n_ell = cl_sacc.metadata['binning/n_ell']
 
-        ell_bins = MyNmtBin.from_binning_info(ell_min, ell_max, n_ell,
-                                              ell_spacing)
+            ell_bins = MyNmtBin.from_binning_info(ell_min, ell_max, n_ell,
+                                                  ell_spacing)
 
         # Check that the binning is compatible with the one in the file
         dtype = cl_sacc.get_data_types()[0]

--- a/txpipe/twopoint_fourier.py
+++ b/txpipe/twopoint_fourier.py
@@ -690,6 +690,7 @@ class TXTwoPointFourier(PipelineStage):
             cl_noise=cl_noise, cl_guess=cl_guess, workspace=workspace, n_iter=1)
 
         if cl_noise is None:
+            cl_noise = np.zeros((c.shape[0], 3*self.config['nside']))
             noise_out = np.zeros_like(c)
         else:
             noise_out = workspace.decouple_cell(cl_noise)[0]

--- a/txpipe/twopoint_fourier.py
+++ b/txpipe/twopoint_fourier.py
@@ -70,7 +70,7 @@ class TXTwoPointFourier(PipelineStage):
         "ell_spacing": 'log',
         "true_shear": False,
         "analytic_noise": True,
-        "ell_edges": [float],
+        "ell_edges": [int],  # NaMaster needs ints
     }
 
     def run(self):
@@ -591,12 +591,17 @@ class TXTwoPointFourier(PipelineStage):
         # Can feed these back upstream if useful.
 
         # Creating the ell binning from the edges using this Namaster constructor.
-        ell_min = self.config['ell_min']
-        ell_max = self.config['ell_max']
-        n_ell = self.config['n_ell']
-        ell_spacing = self.config['ell_spacing']
-        ell_bins = MyNmtBin.from_binning_info(ell_min, ell_max, n_ell,
-                                              ell_spacing)
+        ell_edges = self.config['ell_edges']
+        if len(ell_edges) >= 2.:
+            ell_bins = MyNmtBin.from_edges(ell_edges[:-1], ell_edges[1:],
+                                           is_Dell=False)
+        else:
+            ell_min = self.config['ell_min']
+            ell_max = self.config['ell_max']
+            n_ell = self.config['n_ell']
+            ell_spacing = self.config['ell_spacing']
+            ell_bins = MyNmtBin.from_binning_info(ell_min, ell_max, n_ell,
+                                                  ell_spacing)
         return ell_bins
 
 
@@ -908,10 +913,14 @@ class TXTwoPointFourier(PipelineStage):
 
         # Adding binning information to pass later to TJPCov. I shouldn't be
         # necessary, but it is at the moment.
-        S.metadata['binning/ell_min'] = self.config['ell_min']
-        S.metadata['binning/ell_max'] = self.config['ell_max']
-        S.metadata['binning/ell_spacing'] = self.config['ell_spacing']
-        S.metadata['binning/n_ell'] = self.config['n_ell']
+        ell_edges = self.config['ell_edges']
+        if len(ell_edges) >= 2.:
+            S.metadata['binning/ell_edges'] = str(ell_edges)
+        else:
+            S.metadata['binning/ell_min'] = self.config['ell_min']
+            S.metadata['binning/ell_max'] = self.config['ell_max']
+            S.metadata['binning/ell_spacing'] = self.config['ell_spacing']
+            S.metadata['binning/n_ell'] = self.config['n_ell']
 
         # And we're all done!
         output_filename = self.get_output("twopoint_data_fourier")

--- a/txpipe/twopoint_fourier.py
+++ b/txpipe/twopoint_fourier.py
@@ -693,7 +693,7 @@ class TXTwoPointFourier(PipelineStage):
             cl_noise = np.zeros((c.shape[0], 3*self.config['nside']))
             noise_out = np.zeros_like(c)
         else:
-            noise_out = workspace.decouple_cell(cl_noise)[0]
+            noise_out = workspace.decouple_cell(cl_noise)
 
         def window_pixel(ell, nside):
             r_theta=1/(np.sqrt(3.)*nside)

--- a/txpipe/twopoint_fourier.py
+++ b/txpipe/twopoint_fourier.py
@@ -21,7 +21,7 @@ NAMES = {SHEAR_SHEAR:"shear-shear", SHEAR_POS:"shear-position", POS_POS:"positio
 
 Measurement = collections.namedtuple(
     'Measurement',
-    ['corr_type', 'l', 'value', 'noise', 'win', 'i', 'j'])
+    ['corr_type', 'l', 'value', 'noise', 'noise_cp', 'win', 'i', 'j'])
 
 class TXTwoPointFourier(PipelineStage):
     """This Pipeline Stage computes all auto- and cross-correlations
@@ -643,6 +643,7 @@ class TXTwoPointFourier(PipelineStage):
         CEE=sacc.standard_types.galaxy_shear_cl_ee
         CBB=sacc.standard_types.galaxy_shear_cl_bb
         CEB=sacc.standard_types.galaxy_shear_cl_eb
+        CBE=sacc.standard_types.galaxy_shear_cl_be
         CdE=sacc.standard_types.galaxy_shearDensity_cl_e
         CdB=sacc.standard_types.galaxy_shearDensity_cl_b
         Cdd=sacc.standard_types.galaxy_density_cl
@@ -665,7 +666,7 @@ class TXTwoPointFourier(PipelineStage):
         if k == SHEAR_SHEAR:
             field_i = maps['lf'][i]
             field_j = maps['lf'][j]
-            results_to_use = [(0, CEE, ), (1, CEB, ), (3, CBB, )]
+            results_to_use = [(0, CEE, ), (1, CEB, ), (2, CBE, ), (3, CBB, )]
 
         elif k == POS_POS:
             field_i = maps['df'][i]
@@ -689,9 +690,9 @@ class TXTwoPointFourier(PipelineStage):
             cl_noise=cl_noise, cl_guess=cl_guess, workspace=workspace, n_iter=1)
 
         if cl_noise is None:
-            noise_out = np.zeros(len(ls))
+            noise_out = np.zeros_like(c)
         else:
-            noise_out = workspace.decouple_cell(workspace.couple_cell(cl_noise))[0]
+            noise_out = workspace.decouple_cell(cl_noise)[0]
 
         def window_pixel(ell, nside):
             r_theta=1/(np.sqrt(3.)*nside)
@@ -702,9 +703,11 @@ class TXTwoPointFourier(PipelineStage):
 
         c_beam = c/(window_pixel(ls, self.config['nside']))**2
 
-        # Save all the results, skipping things we don't want like EB modes
+        # Save all the results.
         for index, name in results_to_use:
-            self.results.append(Measurement(name, ls, c_beam[index], noise_out, win, i, j))
+            self.results.append(Measurement(name, ls, c_beam[index],
+                                            noise_out[index], cl_noise[index],
+                                            win, i, j))
 
 
     def compute_noise(self, i, j, k, ell_bins, maps, workspace):
@@ -782,8 +785,9 @@ class TXTwoPointFourier(PipelineStage):
             pxarea = hp.nside2pixarea(nside)
             n_ls = np.mean(var_map)*pxarea
             n_ell = np.zeros((4, 3*nside))
-            n_ell[0, :] = n_ls
-            n_ell[3, :] = n_ls
+            # Note that N_ell = 0 for ell = 1, 2 for shear
+            n_ell[0, 2:] = n_ls
+            n_ell[3, 2:] = n_ls
             return n_ell
         if k == POS_POS:
             metadata = self.open_input('tracer_metadata')
@@ -856,6 +860,7 @@ class TXTwoPointFourier(PipelineStage):
         CEE=sacc.standard_types.galaxy_shear_cl_ee
         CBB=sacc.standard_types.galaxy_shear_cl_bb
         CEB=sacc.standard_types.galaxy_shear_cl_eb
+        CBE=sacc.standard_types.galaxy_shear_cl_be
         CdE=sacc.standard_types.galaxy_shearDensity_cl_e
         CdB=sacc.standard_types.galaxy_shearDensity_cl_b
         Cdd=sacc.standard_types.galaxy_density_cl
@@ -869,8 +874,8 @@ class TXTwoPointFourier(PipelineStage):
         # bin pair and spectrum type, but many data points at different angles.
         # Here we pull them all out to add to sacc
         for d in self.results:
-            tracer1 = f'source_{d.i}' if d.corr_type in [CEE, CBB, CEB, CdE, CdB] else f'lens_{d.i}'
-            tracer2 = f'source_{d.j}' if d.corr_type in [CEE, CEB, CBB] else f'lens_{d.j}'
+            tracer1 = f'source_{d.i}' if d.corr_type in [CEE, CBB, CEB, CBE, CdE, CdB] else f'lens_{d.i}'
+            tracer2 = f'source_{d.j}' if d.corr_type in [CEE, CEB, CBE, CBB] else f'lens_{d.j}'
 
             n = len(d.l)
             for i in range(n):
@@ -879,7 +884,8 @@ class TXTwoPointFourier(PipelineStage):
                 # We use optional tags i and j here to record the bin indices, as well
                 # as in the tracer names, in case it helps to select on them later.
                 S.add_data_point(d.corr_type, (tracer1, tracer2), d.value[i],
-                    ell=d.l[i], window=win, i=d.i, j=d.j, nl=d.noise[i])
+                    ell=d.l[i], window=win, i=d.i, j=d.j, nl=d.noise[i],
+                                 nl_cp=d.noise_cp[i])
 
         # Save provenance information
         provenance = self.gather_provenance()


### PR DESCRIPTION
Instead of recomputing the noise in TJPCov, we pass the noise computed already by TXPipe. 

I have also fixed:

- an error introduced in previous update: I had removed the possibility of using ell_edges for the binning. Now it can be used again as it was. Note that in the way that is (and was) implemented, your last ell_edge must be 3 * nside for the covariance to be computed. 
- the shear analytical noise: Nell = 0 for ell = 1, 2 now