### PR TITLE
Use computed coupled noise in TXTwoPointFourier to compute covariance with TJPCov

### DIFF
--- a/txpipe/covariance.py
+++ b/txpipe/covariance.py
@@ -678,9 +678,9 @@ class TXFourierTJPCovariance(PipelineStage):
             if 'n_ell_coupled' in tr.metadata:
                 tracer_noise[trn] = tr.metadata['n_ell_coupled']
             else:
-                warnings.warn('Missing n_ell_coupled metadata for tracer ' +
-                              f'{trn}. TJPCov will compute it internally. ' +
-                              'Check the consistency.')
+                raise KeyError('Missing n_ell_coupled metadata for tracer ' +
+                              f'{trn}. Something is wrong with the input ' +
+                               'sacc file')
 
         return tracer_noise
 

--- a/txpipe/covariance.py
+++ b/txpipe/covariance.py
@@ -658,9 +658,9 @@ class TXFourierTJPCovariance(PipelineStage):
         calculator = tjpcov.main.CovarianceCalculator({"tjpcov":tjp_config})
 
         cache = {'workspaces': workspaces}
-        tracer_nlcp = self.get_tracer_noise_from_sacc(cl_sacc)
+        tracer_noise_coupled = self.get_tracer_noise_from_sacc(cl_sacc)
         covmat = calculator.get_all_cov_nmt(cache=cache,
-                                            tracer_noise_coupled=tracer_nlcp)
+                                            tracer_noise_coupled=tracer_noise_coupled)
 
         # Write the sacc file with the covariance
         if self.rank == 0:
@@ -675,8 +675,12 @@ class TXFourierTJPCovariance(PipelineStage):
 
         tracer_noise = {}
         for trn, tr in cl_sacc.tracers.items():
-            if 'nl_cp' in tr.metadata:
-                tracer_noise[trn] = tr.metadata['nl_cp']
+            if 'n_ell_coupled' in tr.metadata:
+                tracer_noise[trn] = tr.metadata['n_ell_coupled']
+            else:
+                warnings.warn('Missing n_ell_coupled metadata for tracer ' +
+                              f'{trn}. TJPCov will compute it internally. ' +
+                              'Check the consistency.')
 
         return tracer_noise
 

--- a/txpipe/twopoint_fourier.py
+++ b/txpipe/twopoint_fourier.py
@@ -593,7 +593,7 @@ class TXTwoPointFourier(PipelineStage):
 
         # No noise contribution in cross-correlations
         if (i!=j) or (k==SHEAR_POS):
-            return None
+            return None, None
 
 
         if k == SHEAR_SHEAR:

--- a/txpipe/twopoint_fourier.py
+++ b/txpipe/twopoint_fourier.py
@@ -556,11 +556,9 @@ class TXTwoPointFourier(PipelineStage):
             if nl is not None:
                 c = c - nl
             # Writing out the noise for later cross-checks
-
         else:
             # Get the coupled noise C_ell values to give to the master algorithm
-            nl_cp = self.compute_noise(i, j, k, ell_bins, maps, workspace)
-            nl = workspace.decouple_cell(nl_cp)
+            nl, nl_cp = self.compute_noise(i, j, k, ell_bins, maps, workspace)
             c = nmt.compute_full_master(field_i, field_j, ell_bins,
                                         cl_noise=nl_cp, cl_guess=cl_guess, workspace=workspace, n_iter=1)
 
@@ -640,7 +638,7 @@ class TXTwoPointFourier(PipelineStage):
         if k == POS_POS:
             mean_noise /= 4
 
-        return mean_noise
+        return workspace.decouple_cell(mean_noise), mean_noise
 
 
     def compute_noise_analytic(self, i, j, k, maps, f_sky, workspace):

--- a/txpipe/twopoint_fourier.py
+++ b/txpipe/twopoint_fourier.py
@@ -21,7 +21,7 @@ NAMES = {SHEAR_SHEAR:"shear-shear", SHEAR_POS:"shear-position", POS_POS:"positio
 
 Measurement = collections.namedtuple(
     'Measurement',
-    ['corr_type', 'l', 'value', 'win', 'i', 'j'])
+    ['corr_type', 'l', 'value', 'noise', 'noise_cp', 'win', 'i', 'j'])
 
 class TXTwoPointFourier(PipelineStage):
     """This Pipeline Stage computes all auto- and cross-correlations
@@ -552,16 +552,21 @@ class TXTwoPointFourier(PipelineStage):
             c = nmt.compute_full_master(field_i, field_j, ell_bins,
                                         cl_guess=cl_guess, workspace=workspace, n_iter=1)
             # noise to subtract (already decoupled)
-            cl_noise = self.compute_noise_analytic(i, j, k, maps, f_sky, workspace)
-            if cl_noise is not None:
-                c = c - cl_noise
+            nl, nl_cp = self.compute_noise_analytic(i, j, k, maps, f_sky, workspace)
+            if nl is not None:
+                c = c - nl
             # Writing out the noise for later cross-checks
-            
+
         else:
             # Get the coupled noise C_ell values to give to the master algorithm
-            cl_noise = self.compute_noise(i, j, k, ell_bins, maps, workspace)
+            nl_cp = self.compute_noise(i, j, k, ell_bins, maps, workspace)
+            nl = workspace.decouple_cell(nl_cp)
             c = nmt.compute_full_master(field_i, field_j, ell_bins,
-                                        cl_noise=cl_noise, cl_guess=cl_guess, workspace=workspace, n_iter=1)
+                                        cl_noise=nl_cp, cl_guess=cl_guess, workspace=workspace, n_iter=1)
+
+        if nl is None:
+            nl_cp = np.zeros((c.shape[0], 3*self.config['nside']))
+            nl = np.zeros_like(c)
 
         def window_pixel(ell, nside):
             r_theta=1/(np.sqrt(3.)*nside)
@@ -574,7 +579,9 @@ class TXTwoPointFourier(PipelineStage):
 
         # Save all the results, skipping things we don't want like EB modes
         for index, name in results_to_use:
-            self.results.append(Measurement(name, ls, c_beam[index], win, i, j))
+            self.results.append(Measurement(name, ls, c_beam[index],
+                                            nl[index], nl_cp[index],
+                                            win, i, j))
 
 
     def compute_noise(self, i, j, k, ell_bins, maps, workspace):
@@ -635,13 +642,13 @@ class TXTwoPointFourier(PipelineStage):
 
         return mean_noise
 
-    
+
     def compute_noise_analytic(self, i, j, k, maps, f_sky, workspace):
         # Copied from the HSC branch
         import pymaster
         import healpy as hp
         if (i != j) or (k == SHEAR_POS):
-            return None
+            return None, None
         # This bit only works with healpix maps but it's checked beforehand so that's fine
         if k == SHEAR_SHEAR:
             with self.open_input('source_maps', wrapper=True) as f:
@@ -650,19 +657,22 @@ class TXTwoPointFourier(PipelineStage):
             nside = hp.get_nside(var_map)
             pxarea = hp.nside2pixarea(nside)
             n_ls = np.mean(var_map)*pxarea
-            n_ells = np.array([n_ls*np.ones(3*nside), np.zeros(3*nside), np.zeros(3*nside), n_ls*np.ones(3*nside)])
-            cls_out = workspace.decouple_cell(workspace.couple_cell(n_ells))
-            return cls_out
+            nl_cp = np.zeros((4, 3*nside))
+            # Note that N_ell = 0 for ell = 1, 2 for shear
+            nl_cp[0, 2:] = n_ls
+            nl_cp[3, 2:] = n_ls
 
         if k == POS_POS:
             metadata = self.open_input('tracer_metadata')
             nside = hp.get_nside(maps['dw'])
             ndens = metadata['tracers/lens_density'][i]*3600*180/np.pi*180/np.pi
-            n_ell = np.mean(maps['dw'][maps['dw']>0])/ndens #taking the averages in the mask region for consistency
-            n_ell = [n_ell*np.ones(3*nside)]
-            cls_out = workspace.decouple_cell(workspace.couple_cell(n_ell))
-            return cls_out
-        
+            n_ls = np.mean(maps['dw'][maps['dw']>0])/ndens #taking the averages in the mask region for consistency
+            nl_cp = n_ls * np.ones((1, 3*nside))
+
+        nl = workspace.decouple_cell(nl_cp)
+
+        return nl, nl_cp
+
 
     def load_tomographic_quantities(self, nbin_source, nbin_lens, f_sky):
         # Get lots of bits of metadata from the input file,
@@ -748,7 +758,20 @@ class TXTwoPointFourier(PipelineStage):
                 # We use optional tags i and j here to record the bin indices, as well
                 # as in the tracer names, in case it helps to select on them later.
                 S.add_data_point(d.corr_type, (tracer1, tracer2), d.value[i],
-                    ell=d.l[i], window=win, i=d.i, j=d.j)
+                    ell=d.l[i], window=win, i=d.i, j=d.j, nl=d.noise[i])
+
+            # Add nl_cp to tracer metadata. This will work as far as the
+            # coupled noise is constant
+            tr = S.tracers[tracer1]
+            if (tracer1 == tracer2) and ('nl_cp' not in tr.metadata):
+                if self.config['analytic_noise'] is False:
+                    # If computed through simulations, it might be better to
+                    # take the mean since, for now, only a float can be passed
+                    tr.metadata['nl_cp'] = np.mean(d.noise_cp)
+                else:
+                    # Save the last element because the first one is zero for
+                    # shear
+                    tr.metadata['nl_cp'] = d.noise_cp[-1]
 
         # Save provenance information
         provenance = self.gather_provenance()

--- a/txpipe/twopoint_fourier.py
+++ b/txpipe/twopoint_fourier.py
@@ -765,6 +765,7 @@ class TXTwoPointFourier(PipelineStage):
                 if self.config['analytic_noise'] is False:
                     # If computed through simulations, it might be better to
                     # take the mean since, for now, only a float can be passed
+                    i = 0 if 'lens' in tracer1 else 2
                     tr.metadata['nl_cp'] = np.mean(d.noise_cp)
                 else:
                     # Save the last element because the first one is zero for


### PR DESCRIPTION
I have done the following:
-  Store the noise and coupled noise in the `twopoint_fourier.fits` file. The noise as a tag in each of the data points (copied from the HSC branch) and the coupled noise as a metadata of the tracers. This assumes the coupled noise to be constant and might be necessary to be changed in the future.
- Fix the analytic noise computation. The expressions used give directly the coupled noise not the decoupled. I haven't checked the actual calculation, just assumed it was OK and interpret it as a coupled noise, instead of decouple. I think @damonge agrees with this. @jpratmarti it'd be great if you could have a look at this, since you've been working on it before.