### PR TITLE
Fix readthedocs link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ You can find the outputs in the directory `data/example/outputs_metadetect`
 Learning more
 -------------
 
-See the [ReadTheDocs page for much more documentation](https://txpipe.readthedocs.io/en/).
+See the [ReadTheDocs page for much more documentation](https://txpipe.readthedocs.io/en/latest).
 
 
 Permissions


### PR DESCRIPTION
During the txpipe tutorial today I noticed the link to the ReadTheDocs page was broken in the main README. I think this fixes it.