### PR TITLE
Star challenge: Nicer binned files for PZ to use

### DIFF
--- a/bin/metacal_to_metadet.py
+++ b/bin/metacal_to_metadet.py
@@ -7,7 +7,7 @@ metadet_filename = sys.argv[2]
 bands = "riz"
 prefixes = {"00": "", "1p":"_1p", "1m":"_1m", "2p":"_2p", "2m":"_2m"}
 cols = ["T", "T_err", "g1", "g2", "s2n"] +  [f"mag_{b}" for b in bands] + [f"mag_err_{b}" for b in bands]
-nonprefixed_cols = ["mcal_psf_T_mean","psf_g1", "psf_g2",  "mcal_psf_g1", "mcal_psf_g2", "weight", "redshift_true", "true_g1", "true_g2"]
+nonprefixed_cols = ["mcal_psf_T_mean","psf_g1", "psf_g2",  "mcal_psf_g1", "mcal_psf_g2", "weight", "redshift_true", "true_g1", "true_g2", "ra", "dec", "id"]
 truth_cols = []
 
 with h5py.File(metacal_filename, "r") as infile:

--- a/bin/metacal_to_metadet.py
+++ b/bin/metacal_to_metadet.py
@@ -6,16 +6,18 @@ metadet_filename = sys.argv[2]
 
 bands = "riz"
 prefixes = {"00": "", "1p":"_1p", "1m":"_1m", "2p":"_2p", "2m":"_2m"}
-cols = ["T", "T_err", "g1", "g2", "s2n"] +  [f"mag_{b}" for b in bands] + [f"mag_err_{b}" for b in bands]
+cols = ["flags", "T", "T_err", "g1", "g2", "s2n"] +  [f"mag_{b}" for b in bands] + [f"mag_err_{b}" for b in bands]
 nonprefixed_cols = ["mcal_psf_T_mean","psf_g1", "psf_g2",  "mcal_psf_g1", "mcal_psf_g2", "weight", "redshift_true", "true_g1", "true_g2", "ra", "dec", "id"]
 truth_cols = []
 
 with h5py.File(metacal_filename, "r") as infile:
+    
     with h5py.File(metadet_filename, "w") as outfile:
         outfile.copy(infile["provenance"], "/provenance", expand_external=True)
 
         ingroup = infile["shear"]
         outgroup = outfile.create_group("shear")
+        
         for p in prefixes.keys():
             outgroup.create_group(p)
 

--- a/bin/metacal_to_metadet.py
+++ b/bin/metacal_to_metadet.py
@@ -1,0 +1,109 @@
+import sys
+import h5py
+
+metacal_filename = sys.argv[1]
+metadet_filename = sys.argv[2]
+
+bands = "riz"
+prefixes = {"00": "", "1p":"_1p", "1m":"_1m", "2p":"_2p", "2m":"_2m"}
+cols = ["T", "T_err", "g1", "g2", "s2n"] +  [f"mag_{b}" for b in bands] + [f"mag_err_{b}" for b in bands]
+nonprefixed_cols = ["mcal_psf_T_mean","psf_g1", "psf_g2",  "mcal_psf_g1", "mcal_psf_g2", "weight"]
+truth_cols = ["redshift_true", "true_g1", "true_g2"]
+
+with h5py.File(metacal_filename, "r") as infile:
+    with h5py.File(metadet_filename, "w") as outfile:
+        outfile.copy(infile["provenance"], "/provenance", expand_external=True)
+
+        ingroup = infile["shear"]
+        outgroup = outfile.create_group("shear")
+        for p in prefixes.keys():
+            outgroup.create_group(p)
+
+        for col in cols:
+            for p1, p2 in prefixes.items():
+                print(f"Copying mcal_{col}{p2} -> {p1}/{col}")
+                outgroup[p1].create_dataset(col, data = ingroup[f"mcal_{col}{p2}"][:])
+
+        for col in nonprefixed_cols:
+            for p1 in prefixes.keys():
+                print(f"Copying {col} -> {p1}/{col}")
+                outgroup[p1].create_dataset(col, data = ingroup[f"{col}"][:])
+
+        for col in truth_cols:
+            print(f"Copying {col} -> {col}")
+            outgroup.create_dataset(col, data = ingroup[f"{col}"][:])
+
+
+
+
+# /                        Group
+# /provenance              Group
+# /shear                   Group
+# /shear/dec               Dataset {209892873/2256249331}
+# /shear/id                Dataset {209892873/2256249331}
+# /shear/mcal_T            Dataset {209892873/2256249331}
+# /shear/mcal_T_1m         Dataset {209892873/2256249331}
+# /shear/mcal_T_1p         Dataset {209892873/2256249331}
+# /shear/mcal_T_2m         Dataset {209892873/2256249331}
+# /shear/mcal_T_2p         Dataset {209892873/2256249331}
+# /shear/mcal_T_err        Dataset {209892873/2256249331}
+# /shear/mcal_T_err_1m     Dataset {209892873/2256249331}
+# /shear/mcal_T_err_1p     Dataset {209892873/2256249331}
+# /shear/mcal_T_err_2m     Dataset {209892873/2256249331}
+# /shear/mcal_T_err_2p     Dataset {209892873/2256249331}
+# /shear/mcal_flags        Dataset {209892873/2256249331}
+# /shear/mcal_g1           Dataset {209892873/2256249331}
+# /shear/mcal_g1_1m        Dataset {209892873/2256249331}
+# /shear/mcal_g1_1p        Dataset {209892873/2256249331}
+# /shear/mcal_g1_2m        Dataset {209892873/2256249331}
+# /shear/mcal_g1_2p        Dataset {209892873/2256249331}
+# /shear/mcal_g2           Dataset {209892873/2256249331}
+# /shear/mcal_g2_1m        Dataset {209892873/2256249331}
+# /shear/mcal_g2_1p        Dataset {209892873/2256249331}
+# /shear/mcal_g2_2m        Dataset {209892873/2256249331}
+# /shear/mcal_g2_2p        Dataset {209892873/2256249331}
+# /shear/mcal_mag_err_i    Dataset {209892873/2256249331}
+# /shear/mcal_mag_err_i_1m Dataset {209892873/2256249331}
+# /shear/mcal_mag_err_i_1p Dataset {209892873/2256249331}
+# /shear/mcal_mag_err_i_2m Dataset {209892873/2256249331}
+# /shear/mcal_mag_err_i_2p Dataset {209892873/2256249331}
+# /shear/mcal_mag_err_r    Dataset {209892873/2256249331}
+# /shear/mcal_mag_err_r_1m Dataset {209892873/2256249331}
+# /shear/mcal_mag_err_r_1p Dataset {209892873/2256249331}
+# /shear/mcal_mag_err_r_2m Dataset {209892873/2256249331}
+# /shear/mcal_mag_err_r_2p Dataset {209892873/2256249331}
+# /shear/mcal_mag_err_z    Dataset {209892873/2256249331}
+# /shear/mcal_mag_err_z_1m Dataset {209892873/2256249331}
+# /shear/mcal_mag_err_z_1p Dataset {209892873/2256249331}
+# /shear/mcal_mag_err_z_2m Dataset {209892873/2256249331}
+# /shear/mcal_mag_err_z_2p Dataset {209892873/2256249331}
+# /shear/mcal_mag_i        Dataset {209892873/2256249331}
+# /shear/mcal_mag_i_1m     Dataset {209892873/2256249331}
+# /shear/mcal_mag_i_1p     Dataset {209892873/2256249331}
+# /shear/mcal_mag_i_2m     Dataset {209892873/2256249331}
+# /shear/mcal_mag_i_2p     Dataset {209892873/2256249331}
+# /shear/mcal_mag_r        Dataset {209892873/2256249331}
+# /shear/mcal_mag_r_1m     Dataset {209892873/2256249331}
+# /shear/mcal_mag_r_1p     Dataset {209892873/2256249331}
+# /shear/mcal_mag_r_2m     Dataset {209892873/2256249331}
+# /shear/mcal_mag_r_2p     Dataset {209892873/2256249331}
+# /shear/mcal_mag_z        Dataset {209892873/2256249331}
+# /shear/mcal_mag_z_1m     Dataset {209892873/2256249331}
+# /shear/mcal_mag_z_1p     Dataset {209892873/2256249331}
+# /shear/mcal_mag_z_2m     Dataset {209892873/2256249331}
+# /shear/mcal_mag_z_2p     Dataset {209892873/2256249331}
+# /shear/mcal_s2n          Dataset {209892873/2256249331}
+# /shear/mcal_s2n_1m       Dataset {209892873/2256249331}
+# /shear/mcal_s2n_1p       Dataset {209892873/2256249331}
+# /shear/mcal_s2n_2m       Dataset {209892873/2256249331}
+# /shear/mcal_s2n_2p       Dataset {209892873/2256249331}
+# /shear/psf_g1            Dataset {209892873/2256249331}
+# /shear/psf_g2            Dataset {209892873/2256249331}
+# /shear/ra                Dataset {209892873/2256249331}
+# /shear/redshift_true     Dataset {209892873/2256249331}
+# /shear/true_g1           Dataset {209892873/2256249331}
+# /shear/true_g2           Dataset {209892873/2256249331}
+# /shear/weight            Dataset {209892873/2256249331}
+# /shear/mcal_psf_T_mean   Dataset {209892873/2256249331}
+# /shear/mcal_psf_g1       Dataset {209892873/2256249331}
+# /shear/mcal_psf_g2       Dataset {209892873/2256249331}

--- a/bin/metacal_to_metadet.py
+++ b/bin/metacal_to_metadet.py
@@ -7,8 +7,8 @@ metadet_filename = sys.argv[2]
 bands = "riz"
 prefixes = {"00": "", "1p":"_1p", "1m":"_1m", "2p":"_2p", "2m":"_2m"}
 cols = ["T", "T_err", "g1", "g2", "s2n"] +  [f"mag_{b}" for b in bands] + [f"mag_err_{b}" for b in bands]
-nonprefixed_cols = ["mcal_psf_T_mean","psf_g1", "psf_g2",  "mcal_psf_g1", "mcal_psf_g2", "weight"]
-truth_cols = ["redshift_true", "true_g1", "true_g2"]
+nonprefixed_cols = ["mcal_psf_T_mean","psf_g1", "psf_g2",  "mcal_psf_g1", "mcal_psf_g2", "weight", "redshift_true", "true_g1", "true_g2"]
+truth_cols = []
 
 with h5py.File(metacal_filename, "r") as infile:
     with h5py.File(metadet_filename, "w") as outfile:

--- a/examples/star-challenge/config.yml
+++ b/examples/star-challenge/config.yml
@@ -10,7 +10,7 @@ TXSourceSelectorMetadetect:
     # for selected objects
     source_zbin_edges: [0.0, 0.34, 0.53, 0.71, 0.96, 3.0]
     random_seed: 6765675
-
+    shear_prefix: ''
 
 TXRandomForestLensSelector:
     verbose: False
@@ -42,6 +42,7 @@ TXLensCatalogSplitter:
 
 TXShearCalibration:
     extra_cols:
+        - id
         - mag_err_i
         - mag_err_r
         - mag_err_z

--- a/examples/star-challenge/config.yml
+++ b/examples/star-challenge/config.yml
@@ -1,0 +1,40 @@
+global:
+    chunk_rows: 1000000
+
+TXSourceSelectorMetadetect:
+    bands: riz
+    T_cut: 0.5
+    s2n_cut: 10.0
+    delta_gamma: 0.02
+    # found approximately to split data into equal number counts
+    # for selected objects
+    source_zbin_edges: [0.0, 0.34, 0.53, 0.71, 0.96, 3.0]
+    random_seed: 6765675
+
+
+TXRandomForestLensSelector:
+    verbose: False
+    bands: ugrizy
+    lens_zbin_edges: [0.2, 0.4, 0.6, 0.8, 1.0, 1.2]
+    random_seed: 79521
+    mag_i_limit: 24.1
+
+
+TXLensCatalogSplitter:
+    # save these for the PZ team to play with
+    extra_cols:
+        - id
+        - mag_u
+        - mag_g
+        - mag_r
+        - mag_i
+        - mag_z
+        - mag_y
+        - mag_err_u
+        - mag_err_g
+        - mag_err_r
+        - mag_err_i
+        - mag_err_z
+        - mag_err_y
+        - redshift_true
+    initial_size: 1000000

--- a/examples/star-challenge/config.yml
+++ b/examples/star-challenge/config.yml
@@ -30,11 +30,22 @@ TXLensCatalogSplitter:
         - mag_i
         - mag_z
         - mag_y
-        - mag_err_u
-        - mag_err_g
-        - mag_err_r
-        - mag_err_i
-        - mag_err_z
-        - mag_err_y
+        - mag_u_err
+        - mag_g_err
+        - mag_r_err
+        - mag_i_err
+        - mag_z_err
+        - mag_y_err
         - redshift_true
     initial_size: 1000000
+
+
+TXShearCalibration:
+    extra_cols:
+        - mag_err_i
+        - mag_err_r
+        - mag_err_z
+        - mag_i
+        - mag_r
+        - mag_z
+        - redshift_true

--- a/examples/star-challenge/config.yml
+++ b/examples/star-challenge/config.yml
@@ -50,3 +50,12 @@ TXShearCalibration:
         - mag_r
         - mag_z
         - redshift_true
+
+
+TXSourceTrueNumberDensity:
+    zmax: 3.0
+    nz: 301
+
+TXLensTrueNumberDensity:
+    zmax: 3.0
+    nz: 301

--- a/examples/star-challenge/sample-for-pz.yml
+++ b/examples/star-challenge/sample-for-pz.yml
@@ -16,7 +16,9 @@ stages:
     - name: TXRandomForestLensSelector
       nprocess: 32
     - name: TXLensCatalogSplitter
-      nprocess: 5
+      nprocess: 6
+    - name: TXShearCalibration
+      nprocess: 6
 
 output_dir: data/star-challenge/outputs
 config: examples/star-challenge/config.yml

--- a/examples/star-challenge/sample-for-pz.yml
+++ b/examples/star-challenge/sample-for-pz.yml
@@ -19,6 +19,11 @@ stages:
       nprocess: 6
     - name: TXShearCalibration
       nprocess: 6
+    - name: TXSourceTrueNumberDensity
+      nprocess: 32
+    - name: TXLensTrueNumberDensity
+      nprocess: 32
+    - name: TXPhotozPlots
 
 output_dir: data/star-challenge/outputs
 config: examples/star-challenge/config.yml

--- a/examples/star-challenge/sample-for-pz.yml
+++ b/examples/star-challenge/sample-for-pz.yml
@@ -1,0 +1,38 @@
+launcher:
+    name: mini
+    interval: 3.0
+
+site:
+    name: cori-interactive
+    image: joezuntz/txpipe
+
+modules: txpipe
+
+python_paths: []
+
+stages:
+    - name: TXSourceSelectorMetadetect
+      nprocess: 32
+    - name: TXRandomForestLensSelector
+      nprocess: 32
+    - name: TXLensCatalogSplitter
+      nprocess: 5
+
+output_dir: data/star-challenge/outputs
+config: examples/star-challenge/config.yml
+
+# On NERSC, set this before running:
+# export DATA=${LSST}/groups/WL/users/zuntz/data/metacal-testbed
+
+inputs:
+    # See README for paths to download these files
+    shear_catalog:  /global/projecta/projectdirs/lsst/groups/WL/users/zuntz/data/cosmoDC2-1.1.4_oneyear/metadetect_shear_catalog.hdf5
+    photometry_catalog:  /global/projecta/projectdirs/lsst/groups/WL/users/zuntz/data/cosmoDC2-1.1.4_oneyear/photometry_catalog.hdf5
+    calibration_table:  /global/projecta/projectdirs/lsst/groups/WL/users/zuntz/data/cosmoDC2-1.1.4_oneyear/sample_cosmodc2_w10year_errors.dat
+    fiducial_cosmology: data/fiducial_cosmology.yml
+
+
+resume: True
+log_dir: data/star-challenge/logs
+pipeline_log: data/star-challenge/log.txt
+

--- a/examples/star-challenge/sample-for-pz.yml
+++ b/examples/star-challenge/sample-for-pz.yml
@@ -28,7 +28,7 @@ inputs:
     # See README for paths to download these files
     shear_catalog:  /global/projecta/projectdirs/lsst/groups/WL/users/zuntz/data/cosmoDC2-1.1.4_oneyear/metadetect_shear_catalog.hdf5
     photometry_catalog:  /global/projecta/projectdirs/lsst/groups/WL/users/zuntz/data/cosmoDC2-1.1.4_oneyear/photometry_catalog.hdf5
-    calibration_table:  /global/projecta/projectdirs/lsst/groups/WL/users/zuntz/data/cosmoDC2-1.1.4_oneyear/sample_cosmodc2_w10year_errors.dat
+    calibration_table:  /global/projecta/projectdirs/lsst/groups/WL/users/zuntz/cosmoDC2-1.1.4_oneyear/sample_cosmodc2_w10year_errors.dat
     fiducial_cosmology: data/fiducial_cosmology.yml
 
 

--- a/examples/star-challenge/sample-for-pz.yml
+++ b/examples/star-challenge/sample-for-pz.yml
@@ -28,7 +28,7 @@ inputs:
     # See README for paths to download these files
     shear_catalog:  /global/projecta/projectdirs/lsst/groups/WL/users/zuntz/data/cosmoDC2-1.1.4_oneyear/metadetect_shear_catalog.hdf5
     photometry_catalog:  /global/projecta/projectdirs/lsst/groups/WL/users/zuntz/data/cosmoDC2-1.1.4_oneyear/photometry_catalog.hdf5
-    calibration_table:  /global/projecta/projectdirs/lsst/groups/WL/users/zuntz/cosmoDC2-1.1.4_oneyear/sample_cosmodc2_w10year_errors.dat
+    calibration_table:  /global/projecta/projectdirs/lsst/groups/WL/users/zuntz/data/sample_cosmodc2_w10year_errors.dat
     fiducial_cosmology: data/fiducial_cosmology.yml
 
 

--- a/txpipe/binning/__init__.py
+++ b/txpipe/binning/__init__.py
@@ -1,0 +1,1 @@
+from .random_forest import build_tomographic_classifier, apply_classifier

--- a/txpipe/binning/random_forest.py
+++ b/txpipe/binning/random_forest.py
@@ -1,0 +1,114 @@
+import numpy as np
+
+
+def build_tomographic_classifier(bands, training_file, bin_edges, random_seed, comm):
+    # Load the training data
+    # Build the SOM from the training data
+    from astropy.table import Table
+    from sklearn.ensemble import RandomForestClassifier
+
+    # If we are using multiple processes then only one should do the
+    # classification, to ensure that everything is consistent. In that
+    # case if we are not the root process, wait for them to finish and
+    # receive and return their classifier
+    if (comm is not None) and (comm.rank > 0):
+        classifier = comm.bcast(None)
+        features = comm.bcast(None)
+        return classifier, features
+
+    # Load the training data
+    training_data_table = Table.read(training_file, format="ascii")
+
+    # Pull out the appropriate columns and combinations of the data
+    print(f"Using these bands to train the tomography selector: {bands}")
+
+    # Generate the training data that we will use
+    # We record both the name of the column and the data itself
+    features = []
+    training_data = []
+    for b1 in bands[:]:
+        # First we use the magnitudes themselves
+        features.append(b1)
+        training_data.append(training_data_table[b1])
+        # We also use the colours as training data, even the redundant ones
+        for b2 in bands[:]:
+            if b1 < b2:
+                features.append(f"{b1}-{b2}")
+                training_data.append(training_data_table[b1] - training_data_table[b2])
+    training_data = np.array(training_data).T
+
+    print("Training data for bin classifier has shape ", training_data.shape)
+
+    # Now put the training data into redshift bins
+    # We use -1 to indicate that we are outside the desired ranges
+    z = training_data_table["sz"]
+    training_bin = np.repeat(-1, len(z))
+    print("Using these bin edges:", bin_edges)
+    for i, zmin in enumerate(bin_edges[:-1]):
+        zmax = bin_edges[i + 1]
+        training_bin[(z > zmin) & (z < zmax)] = i
+        ntrain_bin = ((z > zmin) & (z < zmax)).sum()
+        print(f"Training set: {ntrain_bin} objects in tomographic bin {i}")
+
+    # Can be replaced with any classifier
+    classifier = RandomForestClassifier(
+        max_depth=10,
+        max_features=None,
+        n_estimators=20,
+        random_state=random_seed,
+    )
+    classifier.fit(training_data, training_bin)
+
+    # Sklearn fitters can be pickled, which means they can also be sent through
+    # mpi4py
+    if comm is not None:
+        comm.bcast(classifier)
+        comm.bcast(features)
+
+    return classifier, features
+
+
+def apply_classifier(classifier, features, bands, shear_catalog_type, shear_data):
+    """Apply the classifier to the measured magnitudes"""
+
+    if shear_catalog_type == "metacal":
+        prefixes = ["mcal_", "mcal_", "mcal_", "mcal_", "mcal_"]
+        suffixes = ["", "_1p", "_2p", "_1m", "_2m"]
+    elif shear_catalog_type == "metadetect":
+        prefixes = ["00/", "1p/", "2p/", "1m/", "2m/"]
+        suffixes = ["", "", "", "" "", ""]
+    else:
+        prefixes = [""]
+        suffixes = [""]
+
+    pz_data = {}
+
+    for prefix, suffix in zip(prefixes, suffixes):
+        # Pull out the columns that we have trained this bin selection
+        # model on.
+        data = []
+        for f in features:
+            # may be a single band
+            if len(f) == 1:
+                col = shear_data[f"{prefix}mag_{f}{suffix}"]
+            # or a colour
+            else:
+                b1, b2 = f.split("-")
+                col = (
+                    shear_data[f"{prefix}mag_{b1}{suffix}"]
+                    - shear_data[f"{prefix}mag_{b2}{suffix}"]
+                )
+            if np.all(~np.isfinite(col)):
+                # entire column is NaN.  Hopefully this will get deselected elsewhere
+                col[:] = 30.0
+            else:
+                ok = np.isfinite(col)
+                col[~ok] = col[ok].max()
+            data.append(col)
+        data = np.array(data).T
+
+        # Run the random forest on this data chunk
+        pz_data[f"{prefix}zbin{suffix}"] = classifier.predict(data)
+        if shear_catalog_type == "metacal":
+            pz_data[f"zbin{suffix}"] = pz_data[f"{prefix}zbin{suffix}"]
+    return pz_data

--- a/txpipe/lens_selector.py
+++ b/txpipe/lens_selector.py
@@ -2,6 +2,7 @@ from .base_stage import PipelineStage
 from .data_types import YamlFile, TomographyCatalog, HDFFile, TextFile
 from .utils import LensNumberDensityStats
 from .utils import Splitter
+from .binning import build_tomographic_classifier, apply_classifier
 import numpy as np
 import warnings
 
@@ -378,10 +379,10 @@ class TXRandomForestLensSelector(TXBaseLensSelector):
         classifier, features = selector
         shear_catalog_type = "not applicable"
         bands = self.config["bands"]
-        zbin = apply_classifier(
+        pz_data = apply_classifier(
             classifier, features, bands, shear_catalog_type, phot_data
         )
-        return {"zbin": zbin}
+        return pz_data
 
     def select_lens(self, phot_data):
         mag_i = phot_data["mag_i"]

--- a/txpipe/lens_selector.py
+++ b/txpipe/lens_selector.py
@@ -435,7 +435,8 @@ class TXLensCatalogSplitter(PipelineStage):
 
         bins = {b: c for b, c in enumerate(counts)}
         bins["all"] = count2d
-        splitter = Splitter(cat_group, "bin", cols + extra_cols, bins)
+        dtypes = {"id": "i8", "flags": "i8"}
+        splitter = Splitter(cat_group, "bin", cols + extra_cols, bins, dtypes=dtypes)
 
         my_bins = list(self.split_tasks_by_rank(bins))
         if my_bins:

--- a/txpipe/lens_selector.py
+++ b/txpipe/lens_selector.py
@@ -68,6 +68,8 @@ class TXBaseLensSelector(PipelineStage):
 
         iterator = self.data_iterator()
 
+        selector = self.prepare_selector()
+
         # We will collect the selection biases for each bin
         # as a matrix.  We will collect together the different
         # matrices for each chunk and do a weighted average at the end.
@@ -79,7 +81,7 @@ class TXBaseLensSelector(PipelineStage):
         for (start, end, phot_data) in iterator:
             print(f"Process {self.rank} running selection for rows {start:,}-{end:,}")
 
-            pz_data = self.apply_redshift_cut(phot_data)
+            pz_data = self.apply_redshift_cut(phot_data, selector)
 
             # Select lens bin objects
             lens_gals = self.select_lens(phot_data)
@@ -104,7 +106,10 @@ class TXBaseLensSelector(PipelineStage):
         # Restore the original warning settings in case we are being called from a library
         np.seterr(**original_warning_settings)
 
-    def apply_redshift_cut(self, phot_data):
+    def prepare_selector(self):
+        return None
+
+    def apply_redshift_cut(self, phot_data, _):
 
         pz_data = {}
         nbin = len(self.config["lens_zbin_edges"]) - 1
@@ -258,6 +263,7 @@ class TXTruthLensSelector(TXBaseLensSelector):
 
     This is useful for testing with idealised lens bins.
     """
+
     name = "TXTruthLensSelector"
 
     inputs = [
@@ -285,6 +291,7 @@ class TXMeanLensSelector(TXBaseLensSelector):
 
     This requires PDFs to have been estimated earlier.
     """
+
     name = "TXMeanLensSelector"
     inputs = [
         ("photometry_catalog", HDFFile),
@@ -312,6 +319,7 @@ class TXModeLensSelector(TXBaseLensSelector):
 
     This requires PDFs to have been estimated earlier.
     """
+
     name = "TXModeLensSelector"
     inputs = [
         ("photometry_catalog", HDFFile),
@@ -331,6 +339,54 @@ class TXModeLensSelector(TXBaseLensSelector):
         for (s, e, data), (_, _, z_data) in zip(iter_phot, iter_pz):
             data["z"] = z_data["z_mode"]
             yield s, e, data
+
+
+class TXRandomForestLensSelector(TXBaseLensSelector):
+    name = "TXRandomForestSelector"
+    inputs = [
+        ("photometry_catalog", HDFFile),
+        ("calibration_table", TextFile),
+    ]
+    config_options = {
+        "verbose": False,
+        "bands": "ugrizy",
+        "chunk_rows": 10000,
+        "lens_zbin_edges": [float],
+        "random_seed": 42,
+        "mag_i_limit": 24.1,
+    }
+
+    def data_iterator(self):
+        chunk_rows = self.config["chunk_rows"]
+        phot_cols = ["mag_u", "mag_g", "mag_r", "mag_i", "mag_z", "mag_y"]
+
+        for s, e, data in self.iterate_hdf(
+            "photometry_catalog", "photometry", phot_cols, chunk_rows
+        ):
+            yield s, e, data
+
+    def prepare_selector(self):
+        return build_tomographic_classifier(
+            self.config["bands"],
+            self.get_input("calibration_table"),
+            self.config["lens_zbin_edges"],
+            self.config["random_seed"],
+            self.comm,
+        )
+
+    def apply_redshift_cut(self, phot_data, selector):
+        classifier, features = selector
+        shear_catalog_type = "not applicable"
+        bands = self.config["bands"]
+        zbin = apply_classifier(
+            classifier, features, bands, shear_catalog_type, phot_data
+        )
+        return {"zbin": zbin}
+
+    def select_lens(self, phot_data):
+        mag_i = phot_data["mag_i"]
+        limit = self.config["mag_i_limit"]
+        return (mag_i < limit).astype(np.int8)
 
 
 class TXLensCatalogSplitter(PipelineStage):
@@ -354,6 +410,7 @@ class TXLensCatalogSplitter(PipelineStage):
     config_options = {
         "initial_size": 100_000,
         "chunk_rows": 100_000,
+        "extra_cols": [""]
     }
 
     lens_cat_tag = "photometry_catalog"
@@ -366,6 +423,7 @@ class TXLensCatalogSplitter(PipelineStage):
             counts = f["tomography/lens_counts"][:]
             count2d = f["tomography/lens_counts_2d"][:]
 
+        extra_cols = [c for c in self.config["extra_cols"] if c]
         cols = ["ra", "dec", "weight"]
 
         # Object we use to make the separate lens bins catalog
@@ -394,7 +452,7 @@ class TXLensCatalogSplitter(PipelineStage):
             # second file
             self.lens_cat_tag,
             self.lens_cat_sec,
-            ["ra", "dec"],
+            ["ra", "dec"] + extra_cols,
             parallel=False,
         )
 
@@ -422,6 +480,7 @@ class TXExternalLensCatalogSplitter(TXLensCatalogSplitter):
     Implemented as a subclass of TXLensCatalogSplitter, and
     changes only file names.
     """
+
     name = "TXExternalLensCatalogSplitter"
     inputs = [
         ("lens_tomography_catalog", TomographyCatalog),

--- a/txpipe/lens_selector.py
+++ b/txpipe/lens_selector.py
@@ -342,7 +342,7 @@ class TXModeLensSelector(TXBaseLensSelector):
 
 
 class TXRandomForestLensSelector(TXBaseLensSelector):
-    name = "TXRandomForestSelector"
+    name = "TXRandomForestLensSelector"
     inputs = [
         ("photometry_catalog", HDFFile),
         ("calibration_table", TextFile),

--- a/txpipe/lens_selector.py
+++ b/txpipe/lens_selector.py
@@ -435,7 +435,7 @@ class TXLensCatalogSplitter(PipelineStage):
 
         bins = {b: c for b, c in enumerate(counts)}
         bins["all"] = count2d
-        splitter = Splitter(cat_group, "bin", cols, bins)
+        splitter = Splitter(cat_group, "bin", cols + extra_cols, bins)
 
         my_bins = list(self.split_tasks_by_rank(bins))
         if my_bins:

--- a/txpipe/photoz_stack.py
+++ b/txpipe/photoz_stack.py
@@ -405,7 +405,7 @@ class TXSourceTrueNumberDensity(TXPhotozSourceStack):
             has_z = "redshift_true" in photo_file["shear"].keys()
             if not has_z:
                 msg = (
-                    "The photometry_catalog file you supplied does not have a redshift_true column. "
+                    "The shear_catalog file you supplied does not have a redshift_true column. "
                     "If you're running on sims you need to make sure to ingest that column from GCR. "
                     "If you're running on real data then sadly this isn't going to work. "
                     "Use a different stacking stage."

--- a/txpipe/source_selector.py
+++ b/txpipe/source_selector.py
@@ -24,6 +24,7 @@ from .utils.calibrators import (
     LensfitCalibrator,
     HSCCalibrator,
 )
+from .binning import build_tomographic_classifier, apply_classifier
 import numpy as np
 import warnings
 
@@ -151,6 +152,7 @@ class TXSourceSelectorBase(PipelineStage):
 
         # Are we using a metacal or lensfit catalog?
         shear_catalog_type = read_shear_catalog_type(self)
+        bands = self.config["bands"]
 
         # The output file we will put the tomographic
         # information into
@@ -163,7 +165,13 @@ class TXSourceSelectorBase(PipelineStage):
 
         # Build a classifier used to put objects into tomographic bins
         if not (self.config["input_pz"] or self.config["true_z"]):
-            classifier, features = self.build_tomographic_classifier()
+            classifier, features = build_tomographic_classifier(
+                bands,
+                self.get_input("calibration_table"),
+                self.config["source_zbin_edges"],
+                self.config["random_seed"],
+                self.comm,
+            )
 
         # We will collect the selection biases for each bin
         # as a matrix.  We will collect together the different
@@ -187,8 +195,13 @@ class TXSourceSelectorBase(PipelineStage):
 
             else:
                 # or select most likely tomographic source bin, with a random forest
-                pz_data = self.apply_classifier(classifier, features, shear_data)
-
+                pz_data = apply_classifier(
+                    classifier,
+                    features,
+                    bands,
+                    shear_catalog_type,
+                    shear_data,
+                )
             # Combine this selection with size and snr cuts to produce a source selection
             # and calculate the shear bias it would generate
             tomo_bin, R, counts = self.calculate_tomography(
@@ -210,122 +223,6 @@ class TXSourceSelectorBase(PipelineStage):
 
         # Restore the original warning settings in case we are being called from a library
         np.seterr(**original_warning_settings)
-
-    def build_tomographic_classifier(self):
-        # Load the training data
-        # Build the SOM from the training data
-        from astropy.table import Table
-        from sklearn.ensemble import RandomForestClassifier
-
-        # If we are using multiple processes then only one should do the
-        # classification, to ensure that everything is consistent. In that
-        # case if we are not the root process, wait for them to finish and
-        # receive and return their classifier
-        if self.rank > 0:
-            classifier = self.comm.bcast(None)
-            features = self.comm.bcast(None)
-            return classifier, features
-
-        # Load the training data
-        training_file = self.get_input("calibration_table")
-        training_data_table = Table.read(training_file, format="ascii")
-
-        # Pull out the appropriate columns and combinations of the data
-        bands = self.config["bands"]
-        print(f"Using these bands to train the tomography selector: {bands}")
-
-        # Generate the training data that we will use
-        # We record both the name of the column and the data iself
-        features = []
-        training_data = []
-        for b1 in bands[:]:
-            # First we use the magnitudes themselves
-            features.append(b1)
-            training_data.append(training_data_table[b1])
-            # We also use the colours as training data, even the redundant ones
-            for b2 in bands[:]:
-                if b1 < b2:
-                    features.append(f"{b1}-{b2}")
-                    training_data.append(
-                        training_data_table[b1] - training_data_table[b2]
-                    )
-        training_data = np.array(training_data).T
-
-        print("Training data for bin classifier has shape ", training_data.shape)
-
-        # Now put the training data into redshift bins
-        # We use -1 to indicate that we are outside the desired ranges
-        z = training_data_table["sz"]
-        training_bin = np.repeat(-1, len(z))
-        print("Using these bin edges:", self.config["source_zbin_edges"])
-        for i, zmin in enumerate(self.config["source_zbin_edges"][:-1]):
-            zmax = self.config["source_zbin_edges"][i + 1]
-            training_bin[(z > zmin) & (z < zmax)] = i
-            ntrain_bin = ((z > zmin) & (z < zmax)).sum()
-            print(f"Training set: {ntrain_bin} objects in tomographic bin {i}")
-
-        # Can be replaced with any classifier
-        classifier = RandomForestClassifier(
-            max_depth=10,
-            max_features=None,
-            n_estimators=20,
-            random_state=self.config["random_seed"],
-        )
-        classifier.fit(training_data, training_bin)
-
-        # Sklearn fitters can be pickled, which means they can also be sent through
-        # mpi4py
-        if self.is_mpi():
-            self.comm.bcast(classifier)
-            self.comm.bcast(features)
-
-        return classifier, features
-
-    def apply_classifier(self, classifier, features, shear_data):
-        """Apply the classifier to the measured magnitudes"""
-        bands = self.config["bands"]
-
-        if self.config["shear_catalog_type"] == "metacal":
-            prefixes = ["mcal_", "mcal_", "mcal_", "mcal_", "mcal_"]
-            suffixes = ["", "_1p", "_2p", "_1m", "_2m"]
-        elif self.config["shear_catalog_type"] == "metadetect":
-            prefixes = ["00/", "1p/", "2p/", "1m/", "2m/"]
-            suffixes = ["", "", "", "" "", ""]
-        else:
-            prefixes = [""]
-            suffixes = [""]
-
-        pz_data = {}
-
-        for prefix, suffix in zip(prefixes, suffixes):
-            # Pull out the columns that we have trained this bin selection
-            # model on.
-            data = []
-            for f in features:
-                # may be a single band
-                if len(f) == 1:
-                    col = shear_data[f"{prefix}mag_{f}{suffix}"]
-                # or a colour
-                else:
-                    b1, b2 = f.split("-")
-                    col = (
-                        shear_data[f"{prefix}mag_{b1}{suffix}"]
-                        - shear_data[f"{prefix}mag_{b2}{suffix}"]
-                    )
-                if np.all(~np.isfinite(col)):
-                    # entire column is NaN.  Hopefully this will get deselected elsewhere
-                    col[:] = 30.0
-                else:
-                    ok = np.isfinite(col)
-                    col[~ok] = col[ok].max()
-                data.append(col)
-            data = np.array(data).T
-
-            # Run the random forest on this data chunk
-            pz_data[f"{prefix}zbin{suffix}"] = classifier.predict(data)
-            if self.config["shear_catalog_type"] == "metacal":
-                pz_data[f"zbin{suffix}"] = pz_data[f"{prefix}zbin{suffix}"]
-        return pz_data
 
     def apply_simple_redshift_cut(self, shear_data):
         pz_data = {}


### PR DESCRIPTION
This adds a pipeline to generate nicer files for the PZ group to start testing with, and some supporting code.

- A script to make a metacal file into a metadetect one, so I can reuse some old files instead of re-ingesting
- The pipeline YML files
- Moves the random forest binning so it can be used by both source and lens
- Adds a lensing tomography code using the random forest
- Allows saving extra columns in the stages that split the catalogs into bins