### PR TITLE
Add number of patches to file metadata

### DIFF
--- a/txpipe/twopoint.py
+++ b/txpipe/twopoint.py
@@ -427,6 +427,11 @@ class TXTwoPoint(PipelineStage):
             A list of (bin1, bin2, bin_type) where bin1 and bin2 are indices
             or bin labels and bin_type is one of the constants SHEAR_SHEAR,
             SHEAR_POS, or POS_POS.
+
+        meta: dict
+            A dict to which the number of patches (or zero, if no patches) will
+            be added for each catalog type, with keys "npatch_shear", "npatch_pos",
+            and "npatch_ran".
         """
         # Make the full list of catalogs to run
         cats = set()

--- a/txpipe/twopoint.py
+++ b/txpipe/twopoint.py
@@ -98,7 +98,7 @@ class TXTwoPoint(PipelineStage):
         sys.stdout.flush()
 
         # Split the catalogs into patch files
-        self.prepare_patches(calcs)
+        self.prepare_patches(calcs, meta)
 
         results = []
         for i, j, k in calcs:
@@ -414,7 +414,7 @@ class TXTwoPoint(PipelineStage):
         sys.stdout.flush()
         return result
 
-    def prepare_patches(self, calcs):
+    def prepare_patches(self, calcs, meta):
         """
         For each catalog to be generated, have one process load the catalog
         and write its patch files out to disc.  These are then re-used later
@@ -447,6 +447,9 @@ class TXTwoPoint(PipelineStage):
         cats.sort(key=str)
 
         chunk_rows = self.config["chunk_rows"]
+        npatch_shear = 0
+        npatch_pos = 0
+        npatch_ran = 0
 
         # Parallelization is now done at the patch level
         for (h, k) in cats:
@@ -458,20 +461,23 @@ class TXTwoPoint(PipelineStage):
             # them to ensure we don't have two in memory at once.
             if k == SHEAR_SHEAR:
                 cat = self.get_shear_catalog(h)
-                PatchMaker.run(cat, chunk_rows, self.comm)
+                npatch_shear = PatchMaker.run(cat, chunk_rows, self.comm)
                 del cat
             else:
                 cat = self.get_lens_catalog(h)
-                PatchMaker.run(cat, chunk_rows, self.comm)
+                npatch_pos = PatchMaker.run(cat, chunk_rows, self.comm)
                 del cat
 
                 ran_cat = self.get_random_catalog(h)
                 # support use_randoms = False
                 if ran_cat is None:
                     continue
-                PatchMaker.run(ran_cat, chunk_rows, self.comm)
+                npatch_ran = PatchMaker.run(ran_cat, chunk_rows, self.comm)
                 del ran_cat
 
+        meta["npatch_shear"] = npatch_shear
+        meta["npatch_pos"] = npatch_pos
+        meta["npatch_ran"] = npatch_ran
         # stop other processes progressing to the rest of the code and
         # trying to load things we have not written yet
         if self.comm is not None:

--- a/txpipe/utils/patches.py
+++ b/txpipe/utils/patches.py
@@ -241,15 +241,17 @@ class PatchMaker:
                 print(
                     f"Catalog {cat.file_name} does not have a patch directory set, so not making patches."
                 )
-            return
+            return 0
 
         patch_filenames = cat.get_patch_file_names(cat.save_patch_dir)
+
+        npatch = len(cat.patch_centers)
 
         # Check for existing patches.
         if cls.patches_already_made(cat):
             if comm is None or comm.rank == 0:
                 print(f"Patches already done for {cat.save_patch_dir}")
-            return
+            return npatch
 
         # find the catalog full length, which we use as a maximum possible size
         with h5py.File(cat.file_name, "r") as f:
@@ -257,7 +259,6 @@ class PatchMaker:
             ra_col = cat.config["ra_col"]
             max_size = g[ra_col].size
 
-        npatch = len(cat.patch_centers)
 
         # Do the parallelization - split up the patches in chunks
         if comm is None:
@@ -339,3 +340,5 @@ class PatchMaker:
         # finished renaming
         if comm is not None:
             comm.Barrier()
+
+        return npatch

--- a/txpipe/utils/patches.py
+++ b/txpipe/utils/patches.py
@@ -222,6 +222,11 @@ class PatchMaker:
             Number of rows of data to read at once on each process
         comm: communicator or None
             MPI communicator for parallel runs
+
+        Returns
+        -------
+        npatch: int
+            The number of patches created for this file, or 0 if there are none
         """
         import h5py
 


### PR DESCRIPTION
Saves the number of patches as metadata in the sacc file output when present.

Closes #176 