### PR TITLE
Save bandpowers and enable Fourier stages in testing

### DIFF
--- a/examples/metadetect/config.yml
+++ b/examples/metadetect/config.yml
@@ -7,7 +7,7 @@ global:
     chunk_rows: 100000
     # These mapping options are also read by a range of stages
     pixelization: healpix
-    nside: 512
+    nside: 64
     sparse: True  # Generate sparse maps - faster if using small areas
 
 TXGCRTwoCatalogInput:
@@ -226,7 +226,10 @@ TXJackknifeCenters:
 
 TXTwoPointFourier:
     flip_g2: True
-    bandwidth: 100
+    ell_min: 30
+    ell_max: 150
+    bandwidth: 20
+    cache_dir: ./cache/workspaces
 
 TXSimpleMask:
     depth_cut : 23.5

--- a/examples/metadetect/pipeline.yml
+++ b/examples/metadetect/pipeline.yml
@@ -20,7 +20,6 @@ stages:
     # - name: PZRailEstimateLens # Compute p(z) values for the lens sample
     - name: TXPhotozSourceStack  # Stack p(z) into n(z)
     - name: TXPhotozLensStack    # Stack p(z) into n(z)
-    # - name: TXMainMaps
     - name: TXSourceMaps           # make source g1 and g2 maps
     - name: TXLensMaps           # make source lens and n_gal maps
     - name: TXAuxiliarySourceMaps  # make PSF and flag maps
@@ -57,6 +56,9 @@ stages:
     - name: TXMapCorrelations    # plot the correlations between systematics and data
     - name: TXApertureMass        # Compute aperture-mass statistics
       threads_per_process: 2
+    - name: TXSourceNoiseMaps    # Compute shear noise using rotations
+    - name: TXLensNoiseMaps      # Compute lens noise using half-splits
+    - name: TXTwoPointFourier    # Compute power spectra C_ell
 
     # Disabled since not yet synchronised with new Treecorr MPI
     # - name: TXSelfCalibrationIA   # Self-calibration intrinsic alignments of galaxies
@@ -64,7 +66,6 @@ stages:
     # Disabling these as they takes too long for a quick test.
     # The latter two need NaMaster
     # - name: TXRealGaussianCovariance   # Compute covariance of real-space correlations
-    # - name: TXTwoPointFourier          # Compute power spectra C_ell
     # - name: TXFourierGaussianCovariance # Compute the C_ell covariance
 
 

--- a/txpipe/twopoint_fourier.py
+++ b/txpipe/twopoint_fourier.py
@@ -268,15 +268,6 @@ class TXTwoPointFourier(PipelineStage):
                             )
                             syst_map = healpy.read_map(systmap_file, verbose=False)
 
-                            #                             # Find value at given ra,dec
-                            #                             ra = 55.
-                            #                             dec = -30.
-                            #                             theta = 0.5 * np.pi - np.deg2rad(dec)
-                            #                             phi = np.deg2rad(ra)
-                            #                             nside = healpy.pixelfunc.get_nside(syst_map)
-                            #                             ipix = healpy.ang2pix(nside, theta, phi)
-                            #                             print('Syst map: value at ra,dec = 55,-30: ', syst_map[ipix])
-
                             # normalize map for Namaster
                             # set pixel values to value/mean - 1
                             syst_map_mask = syst_map != healpy.UNSEEN

--- a/txpipe/utils/nmt_utils.py
+++ b/txpipe/utils/nmt_utils.py
@@ -87,7 +87,7 @@ class MyNmtBin(nmt.NmtBin):
 class WorkspaceCache:
     def __init__(self, dirname):
         self.path = pathlib.Path(dirname)
-        self.path.mkdir(exist_ok=True)
+        self.path.mkdir(parents=True, exist_ok=True)
         self._loaded = {}
 
     def get(self, key):


### PR DESCRIPTION
This change extracts the bandpower values from namaster and saves them to sacc.

It also enables the Fourier stage in the continuous integration (just the metadetect pipeline) by dropping down to nside 64 so it runs in a reasonable amount of time.