### PR TITLE
Print out metric in TXTwoPoint

### DIFF
--- a/examples/lensfit/config.yml
+++ b/examples/lensfit/config.yml
@@ -108,6 +108,8 @@ TXTwoPoint:
     verbose: 0
     shear_catalog_type: metacal
     subtract_mean_shear: True
+    # Using the arc metric here to test it works
+    metric: Arc
 
 TXGammaTBrightStars:
     shear_catalog_type: metacal

--- a/examples/lensfit/pipeline.yml
+++ b/examples/lensfit/pipeline.yml
@@ -3,7 +3,7 @@
 stages:
     - name: TXSourceSelectorLensfit
     - name: TXShearCalibration
-    - name: TXLensCatalogSplitter
+    - name: TXLensCatalogSplitter3D
     - name: TXStarCatalogSplitter
     - name: TXTruthLensSelector
     - name: PZRailTrainLens

--- a/examples/redmagic/pipeline.yml
+++ b/examples/redmagic/pipeline.yml
@@ -3,7 +3,7 @@
 stages:
     - name: TXSourceSelectorMetacal
     - name: TXShearCalibration
-    - name: TXExternalLensCatalogSplitter
+    - name: TXExternalLensCatalogSplitter3D
     - name: TXStarCatalogSplitter
     - name: TXSourceTrueNumberDensity
     - name: TXIngestRedmagic
@@ -19,6 +19,8 @@ stages:
     - name: TXJackknifeCenters
     - name: TXPhotozPlots
     - name: TXTwoPoint
+      threads_per_process: 2
+    - name: TXTwoPointRLens
       threads_per_process: 2
     - name: TXBlinding           # Blind the data following Muir et al
       threads_per_process: 2

--- a/txpipe/__init__.py
+++ b/txpipe/__init__.py
@@ -44,4 +44,5 @@ from .calibrate import TXShearCalibration
 # Here are the stages that mostly will be used for other projects
 # such as the self-calibration of Intrinsic alignment.
 from .extensions.twopoint_scia import TXSelfCalibrationIA
+from .extensions.clmm import TXTwoPointRLens
 from .covariance_nmt import TXFourierNamasterCovariance, TXRealNamasterCovariance

--- a/txpipe/extensions/clmm/__init__.py
+++ b/txpipe/extensions/clmm/__init__.py
@@ -1,0 +1,1 @@
+from .rlens import TXTwoPointRLens

--- a/txpipe/extensions/clmm/rlens.py
+++ b/txpipe/extensions/clmm/rlens.py
@@ -1,0 +1,116 @@
+from ...twopoint import TXTwoPoint
+from ...data_types import (
+    HDFFile,
+    ShearCatalog,
+    PNGFile,
+    TextFile,
+)
+import numpy as np
+
+
+class TXTwoPointRLens(TXTwoPoint):
+    """
+    Measure 2-pt shear-position using the Rlens metric
+
+    The Rlens metric uses the impact factor between the vector to the source galaxy
+    and the location of the lens galaxy as its distance.
+
+    Compared to the parent TXTwoPoint class this:
+    - does only the shear-position correlation
+    - loads comoving coordinates as the radial distance in the lens and random catalogs
+    - removes the sep_unit configuration option since the unit must always be Mpc
+    - changes the default metric
+    - does not yet save any results correctly, just prints them out.
+
+    This is mainly an example stage for future CL work.
+
+    """
+    name = "TXTwoPointRLens"
+    inputs = [
+        ("binned_lens_catalog", HDFFile),
+        ("binned_shear_catalog", HDFFile),
+        ("binned_random_catalog", HDFFile),
+        ("patch_centers", TextFile),
+        ("tracer_metadata", HDFFile),
+    ]
+    outputs = []
+
+
+    config_options = {
+        # TODO: Allow more fine-grained selection of 2pt subsets to compute
+        "calcs": [0, 1, 2],
+        "min_sep": 1.0,  # Megaparsec
+        "max_sep": 50.0, # Megaparsec
+        "nbins": 9,
+        "bin_slop": 0.1,
+        "flip_g1": False,
+        "flip_g2": True,
+        "cores_per_task": 20,
+        "verbose": 1,
+        "source_bins": [-1],
+        "lens_bins": [-1],
+        "reduce_randoms_size": 1.0,
+        "do_shear_shear": False,
+        "do_shear_pos": True,
+        "do_pos_pos": False,
+        "var_method": "jackknife",
+        "use_randoms": True,
+        "low_mem": False,
+        "patch_dir": "./cache/patches",
+        "chunk_rows": 100_000,
+        "share_patch_files": False,
+        "metric": "Rlens",
+    }
+
+    def get_lens_catalog(self, i):
+        # Override the lens catalog generation.
+        # This is like the parent version except we also add the r_col keyword
+        import treecorr
+
+        cat = treecorr.Catalog(
+            self.get_input("binned_lens_catalog"),
+            ext=f"/lens/bin_{i}",
+            ra_col="ra",
+            dec_col="dec",
+            r_col="comoving_distance",
+            w_col="weight",
+            ra_units="degree",
+            dec_units="degree",
+            patch_centers=self.get_input("patch_centers"),
+            save_patch_dir=self.get_patch_dir("binned_lens_catalog", i),
+        )
+        return cat
+
+    def get_random_catalog(self, i):
+        # As with the lens catalog version, we add the r_col keyword
+        # compare to the parent class
+        import treecorr
+
+        if not self.config["use_randoms"]:
+            return None
+
+        rancat = treecorr.Catalog(
+            self.get_input("binned_random_catalog"),
+            ext=f"/randoms/bin_{i}",
+            ra_col="ra",
+            dec_col="dec",
+            r_col="comoving_distance",
+            ra_units="degree",
+            dec_units="degree",
+            patch_centers=self.get_input("patch_centers"),
+            save_patch_dir=self.get_patch_dir("binned_random_catalog", i),
+        )
+        return rancat
+
+    def call_treecorr(self, i, j, k):
+        # The parent class uses the label for gamma_t measurements
+        # here, so we overwrite it.
+        result = super().call_treecorr(i, j, k)
+        # choose a better name maybe!
+        return result._replace(corr_type = "galaxy_shearDensity_rlens")
+
+
+    def write_output(self, source_list, lens_list, meta, results):
+        for result in results:
+            print(result.i, result.j, result.object.xi)
+            print("")

--- a/txpipe/extensions/clmm/rlens.py
+++ b/txpipe/extensions/clmm/rlens.py
@@ -33,7 +33,7 @@ class TXTwoPointRLens(TXTwoPoint):
         ("patch_centers", TextFile),
         ("tracer_metadata", HDFFile),
     ]
-    outputs = []
+    outputs = [("rlens_measurement", TextFile)]
 
     config_options = {
         # TODO: Allow more fine-grained selection of 2pt subsets to compute
@@ -109,6 +109,10 @@ class TXTwoPointRLens(TXTwoPoint):
         return result._replace(corr_type="galaxy_shearDensity_rlens")
 
     def write_output(self, source_list, lens_list, meta, results):
-        for result in results:
-            print(result.i, result.j, result.object.xi)
-            print("")
+        with self.open_output("rlens_measurement") as f:
+            print("#i_bin  j_bin  mean_r_Mpc  rlens")
+            print("#i_bin  j_bin  mean_r_Mpc  rlens", file=f)
+            for result in results:
+                for logr, xi in zip(result.object.meanlogr, result.object.xi):
+                    print(result.i, result.j, np.exp(logr), xi)
+                    print(result.i, result.j, np.exp(logr), xi, file=f)

--- a/txpipe/extensions/clmm/rlens.py
+++ b/txpipe/extensions/clmm/rlens.py
@@ -35,12 +35,11 @@ class TXTwoPointRLens(TXTwoPoint):
     ]
     outputs = []
 
-
     config_options = {
         # TODO: Allow more fine-grained selection of 2pt subsets to compute
         "calcs": [0, 1, 2],
         "min_sep": 1.0,  # Megaparsec
-        "max_sep": 50.0, # Megaparsec
+        "max_sep": 50.0,  # Megaparsec
         "nbins": 9,
         "bin_slop": 0.1,
         "flip_g1": False,
@@ -107,8 +106,7 @@ class TXTwoPointRLens(TXTwoPoint):
         # here, so we overwrite it.
         result = super().call_treecorr(i, j, k)
         # choose a better name maybe!
-        return result._replace(corr_type = "galaxy_shearDensity_rlens")
-
+        return result._replace(corr_type="galaxy_shearDensity_rlens")
 
     def write_output(self, source_list, lens_list, meta, results):
         for result in results:

--- a/txpipe/ingest_redmagic.py
+++ b/txpipe/ingest_redmagic.py
@@ -56,7 +56,7 @@ class TXIngestRedmagic(PipelineStage):
         g.create_dataset("ra", (n,), dtype=np.float64)
         g.create_dataset("dec", (n,), dtype=np.float64)
         g.create_dataset("chisq", (n,), dtype=np.float64)
-        g.create_dataset("zredmagic", (n,), dtype=np.float64)
+        g.create_dataset("redshift", (n,), dtype=np.float64)
         for b in "grizy":
             g.create_dataset(f"mag_{b}", (n,), dtype=np.float64)
             g.create_dataset(f"mag_err_{b}", (n,), dtype=np.float64)
@@ -109,7 +109,7 @@ class TXIngestRedmagic(PipelineStage):
             g["ra"][s:e] = data["ra"]
             g["dec"][s:e] = data["dec"]
             g["chisq"][s:e] = data["chisq"]
-            g["zredmagic"][s:e] = data["zredmagic"]
+            g["redshift"][s:e] = data["zredmagic"]
 
             # including mags
             for i, b in enumerate(bands):

--- a/txpipe/lens_selector.py
+++ b/txpipe/lens_selector.py
@@ -1,5 +1,5 @@
 from .base_stage import PipelineStage
-from .data_types import YamlFile, TomographyCatalog, HDFFile, TextFile
+from .data_types import YamlFile, TomographyCatalog, HDFFile, TextFile, FiducialCosmology
 from .utils import LensNumberDensityStats
 from .utils import Splitter
 from .binning import build_tomographic_classifier, apply_classifier
@@ -414,9 +414,6 @@ class TXLensCatalogSplitter(PipelineStage):
         "extra_cols": [""]
     }
 
-    lens_cat_tag = "photometry_catalog"
-    lens_cat_sec = "photometry"
-
     def run(self):
 
         with self.open_input("lens_tomography_catalog") as f:
@@ -445,20 +442,7 @@ class TXLensCatalogSplitter(PipelineStage):
         else:
             print(f"Note: Process {self.rank} will not do anything.")
 
-        it = self.combined_iterators(
-            self.config["chunk_rows"],
-            # first file
-            "lens_tomography_catalog",
-            "tomography",
-            ["lens_bin", "lens_weight"],
-            # second file
-            self.lens_cat_tag,
-            self.lens_cat_sec,
-            ["ra", "dec"] + extra_cols,
-            parallel=False,
-        )
-
-        for s, e, data in it:
+        for s, e, data in self.data_iterator():
             if self.rank == 0:
                 print(f"Process 0 binning data in range {s:,} - {e:,}")
 
@@ -474,6 +458,21 @@ class TXLensCatalogSplitter(PipelineStage):
         splitter.finish(my_bins)
         cat_output.close()
 
+    def data_iterator(self):
+        extra_cols = [c for c in self.config["extra_cols"] if c]
+        return self.combined_iterators(
+            self.config["chunk_rows"],
+            # first file
+            "lens_tomography_catalog",
+            "tomography",
+            ["lens_bin", "lens_weight"],
+            # second file
+            "photometry_catalog",
+            "photometry",
+            ["ra", "dec"] + extra_cols,
+            parallel=False,
+        )
+
 
 class TXExternalLensCatalogSplitter(TXLensCatalogSplitter):
     """
@@ -487,10 +486,131 @@ class TXExternalLensCatalogSplitter(TXLensCatalogSplitter):
     inputs = [
         ("lens_tomography_catalog", TomographyCatalog),
         ("lens_catalog", HDFFile),
+        ("fiducial_cosmology", FiducialCosmology),
     ]
-    lens_cat_tag = "lens_catalog"
 
-    lens_cat_sec = "lens"
+    def data_iterator(self):
+        extra_cols = [c for c in self.config["extra_cols"] if c]
+        return self.combined_iterators(
+            self.config["chunk_rows"],
+            # first file
+            "lens_tomography_catalog",
+            "tomography",
+            ["lens_bin", "lens_weight"],
+            # second file
+            "lens_catalog",
+            "lens",
+            ["ra", "dec"] + extra_cols,
+            parallel=False,
+        )
+
+
+class TXLensCatalogSplitter3D(TXLensCatalogSplitter):
+    """
+    Split up a lens catalog into bins and add a radial coordinate
+
+    The radial coordinate is generated from the redshift and a fiducial cosmology.
+    The redshift column can be selected; by default it is the mean z.
+    """
+    name = "TXLensCatalogSplitter3D"
+    inputs = [
+        ("lens_tomography_catalog", TomographyCatalog),
+        ("photometry_catalog", HDFFile),
+        ("fiducial_cosmology", FiducialCosmology),
+        ("lens_photoz_pdfs", HDFFile),
+    ]
+
+    config_options = TXLensCatalogSplitter.config_options.copy()
+    config_options["redshift_column"] = "z_mean"
+
+    def run(self):
+        # Add comoving distance to extra cols if needed.
+        self.config["extra_cols"].append("comoving_distance")
+        super().run()
+
+    def data_iterator(self):
+        import pyccl
+
+        z_col = self.config["redshift_column"]
+        extra_cols = [c for c in self.config["extra_cols"] if c and c != "comoving_distance"]
+
+        with self.open_input("fiducial_cosmology", wrapper=True) as f:
+            cosmo = f.to_ccl()
+
+        it = self.combined_iterators(
+            self.config["chunk_rows"],
+            # first file
+            "lens_tomography_catalog",
+            "tomography",
+            ["lens_bin", "lens_weight"],
+            # second file
+            "photometry_catalog",
+            "photometry",
+            ["ra", "dec"] + extra_cols,
+            "lens_photoz_pdfs",
+            "point_estimates",
+            [z_col],
+            parallel=False,
+        )
+
+        for s, e, data in it:
+            z = data[z_col]
+            a = 1.0 / (1 + z)
+            d = pyccl.comoving_radial_distance(cosmo, a)
+            data["comoving_distance"] = d
+            yield s, e, data
+
+class TXExternalLensCatalogSplitter3D(TXLensCatalogSplitter):
+    """
+    Split an external lens catalog into bins, and add a radial coordinate.
+
+    Like TXLensCatalogSplitter3D this adds uses the redshift (z_mean, by default)
+    and a fiducial cosmology.
+    """
+    name = "TXExternalLensCatalogSplitter3D"
+    inputs = [
+        ("lens_tomography_catalog", TomographyCatalog),
+        ("lens_catalog", HDFFile),
+        ("fiducial_cosmology", FiducialCosmology),
+    ]
+
+    def run(self):
+        self.config["extra_cols"].append("comoving_distance")
+        super().run()
+
+    def data_iterator(self):
+        import pyccl
+
+        # We load all cols except for comoving distance, which we calculate
+        extra_cols = [c for c in self.config["extra_cols"] if c and c != "comoving_distance"]
+
+        # We need to read the redshift in to compute the distance
+        if "redshift" not in extra_cols:
+            extra_cols.append("redshift")
+
+        with self.open_input("fiducial_cosmology", wrapper=True) as f:
+            cosmo = f.to_ccl()
+
+        it = self.combined_iterators(
+            self.config["chunk_rows"],
+            # first file
+            "lens_tomography_catalog",
+            "tomography",
+            ["lens_bin", "lens_weight"],
+            # second file
+            "lens_catalog",
+            "lens",
+            ["ra", "dec"] + extra_cols,
+            parallel=False,
+        )
+
+        for s, e, data in it:
+            z = data.pop("redshift")
+            a = 1.0 / (1 + z)
+            d = pyccl.comoving_radial_distance(cosmo, a)
+            data["comoving_distance"] = d
+            yield s, e, data
+
 
 
 if __name__ == "__main__":

--- a/txpipe/lens_selector.py
+++ b/txpipe/lens_selector.py
@@ -562,6 +562,9 @@ class TXLensCatalogSplitter3D(TXLensCatalogSplitter):
             parallel=False,
         )
 
+        # This iterates through chunks of the input catalogs, but for each
+        # chunk it also intercepts and adds the radial distance. So this function
+        # returns an iterator, just like combined_iterators does.
         for s, e, data in it:
             z = data[z_col]
             a = 1.0 / (1 + z)
@@ -617,6 +620,8 @@ class TXExternalLensCatalogSplitter3D(TXLensCatalogSplitter):
             parallel=False,
         )
 
+        # See the explanation of this in the TXLensCatalogSplitter3D
+        # class above
         for s, e, data in it:
             z = data.pop("redshift")
             a = 1.0 / (1 + z)

--- a/txpipe/lens_selector.py
+++ b/txpipe/lens_selector.py
@@ -1,5 +1,11 @@
 from .base_stage import PipelineStage
-from .data_types import YamlFile, TomographyCatalog, HDFFile, TextFile, FiducialCosmology
+from .data_types import (
+    YamlFile,
+    TomographyCatalog,
+    HDFFile,
+    TextFile,
+    FiducialCosmology,
+)
 from .utils import LensNumberDensityStats
 from .utils import Splitter
 from .binning import build_tomographic_classifier, apply_classifier
@@ -411,7 +417,7 @@ class TXLensCatalogSplitter(PipelineStage):
     config_options = {
         "initial_size": 100_000,
         "chunk_rows": 100_000,
-        "extra_cols": [""]
+        "extra_cols": [""],
     }
 
     def run(self):
@@ -512,6 +518,7 @@ class TXLensCatalogSplitter3D(TXLensCatalogSplitter):
     The radial coordinate is generated from the redshift and a fiducial cosmology.
     The redshift column can be selected; by default it is the mean z.
     """
+
     name = "TXLensCatalogSplitter3D"
     inputs = [
         ("lens_tomography_catalog", TomographyCatalog),
@@ -532,7 +539,9 @@ class TXLensCatalogSplitter3D(TXLensCatalogSplitter):
         import pyccl
 
         z_col = self.config["redshift_column"]
-        extra_cols = [c for c in self.config["extra_cols"] if c and c != "comoving_distance"]
+        extra_cols = [
+            c for c in self.config["extra_cols"] if c and c != "comoving_distance"
+        ]
 
         with self.open_input("fiducial_cosmology", wrapper=True) as f:
             cosmo = f.to_ccl()
@@ -560,6 +569,7 @@ class TXLensCatalogSplitter3D(TXLensCatalogSplitter):
             data["comoving_distance"] = d
             yield s, e, data
 
+
 class TXExternalLensCatalogSplitter3D(TXLensCatalogSplitter):
     """
     Split an external lens catalog into bins, and add a radial coordinate.
@@ -567,6 +577,7 @@ class TXExternalLensCatalogSplitter3D(TXLensCatalogSplitter):
     Like TXLensCatalogSplitter3D this adds uses the redshift (z_mean, by default)
     and a fiducial cosmology.
     """
+
     name = "TXExternalLensCatalogSplitter3D"
     inputs = [
         ("lens_tomography_catalog", TomographyCatalog),
@@ -582,7 +593,9 @@ class TXExternalLensCatalogSplitter3D(TXLensCatalogSplitter):
         import pyccl
 
         # We load all cols except for comoving distance, which we calculate
-        extra_cols = [c for c in self.config["extra_cols"] if c and c != "comoving_distance"]
+        extra_cols = [
+            c for c in self.config["extra_cols"] if c and c != "comoving_distance"
+        ]
 
         # We need to read the redshift in to compute the distance
         if "redshift" not in extra_cols:
@@ -610,7 +623,6 @@ class TXExternalLensCatalogSplitter3D(TXLensCatalogSplitter):
             d = pyccl.comoving_radial_distance(cosmo, a)
             data["comoving_distance"] = d
             yield s, e, data
-
 
 
 if __name__ == "__main__":

--- a/txpipe/random_cats.py
+++ b/txpipe/random_cats.py
@@ -136,7 +136,7 @@ class TXRandomCat(PipelineStage):
         ra_out = group.create_dataset("ra", (n_total,), dtype=np.float64)
         dec_out = group.create_dataset("dec", (n_total,), dtype=np.float64)
         z_out = group.create_dataset("z", (n_total,), dtype=np.float64)
-        z_out = group.create_dataset("comoving_distance", (n_total,), dtype=np.float64)
+        chi_out = group.create_dataset("comoving_distance", (n_total,), dtype=np.float64)
         bin_out = group.create_dataset("bin", (n_total,), dtype=np.int16)
 
         # Second output is specific to an individual bin, so we can just load

--- a/txpipe/random_cats.py
+++ b/txpipe/random_cats.py
@@ -1,5 +1,5 @@
 from .base_stage import PipelineStage
-from .data_types import MapsFile, YamlFile, RandomsCatalog, TomographyCatalog, HDFFile
+from .data_types import MapsFile, YamlFile, RandomsCatalog, TomographyCatalog, HDFFile, FiducialCosmology
 from .utils import choose_pixelization, Splitter
 import numpy as np
 
@@ -15,6 +15,7 @@ class TXRandomCat(PipelineStage):
     inputs = [
         ("aux_lens_maps", MapsFile),
         ("lens_photoz_stack", HDFFile),
+        ("fiducial_cosmology", FiducialCosmology),
     ]
     outputs = [
         ("random_cats", RandomsCatalog),
@@ -31,6 +32,7 @@ class TXRandomCat(PipelineStage):
         import scipy.special
         import scipy.stats
         import healpy
+        import pyccl
         from . import randoms
         from .utils.hdf_tools import BatchWriter
 
@@ -42,6 +44,12 @@ class TXRandomCat(PipelineStage):
             scheme = choose_pixelization(**info)
 
         pz_stack = self.open_input("lens_photoz_stack")
+
+        # We also generate comoving distances under a fiducial cosmology
+        # for each random, for use in Rlens type metrics
+        with self.open_input("fiducial_cosmology", wrapper=True) as f:
+            cosmo = f.to_ccl()
+
 
         # Cut down to pixels that have any objects in
         pixel = np.where(depth > 0)[0]
@@ -121,6 +129,7 @@ class TXRandomCat(PipelineStage):
         ra_out = group.create_dataset("ra", (n_total,), dtype=np.float64)
         dec_out = group.create_dataset("dec", (n_total,), dtype=np.float64)
         z_out = group.create_dataset("z", (n_total,), dtype=np.float64)
+        z_out = group.create_dataset("comoving_distance", (n_total,), dtype=np.float64)
         bin_out = group.create_dataset("bin", (n_total,), dtype=np.int16)
 
         # Second output is specific to an individual bin, so we can just load
@@ -135,6 +144,7 @@ class TXRandomCat(PipelineStage):
             g.create_dataset("ra", (bin_counts[i],))
             g.create_dataset("dec", (bin_counts[i],))
             g.create_dataset("z", (bin_counts[i],))
+            g.create_dataset("comoving_distance", (bin_counts[i],))
             subgroups.append(g)
 
         pixels_per_proc = npix // self.size
@@ -161,13 +171,13 @@ class TXRandomCat(PipelineStage):
             # still work.
             batch1 = BatchWriter(
                 group,
-                {"ra": np.float64, "dec": np.float64, "z": np.float64, "bin": np.int16},
+                {"ra": np.float64, "dec": np.float64, "z": np.float64, "comoving_distance": np.float64, "bin": np.int16},
                 offset=bin_starts[j] + pix_starts[j, start_vertex],
                 max_size=self.config["chunk_rows"],
             )
             batch2 = BatchWriter(
                 subgroup,
-                {"ra": np.float64, "dec": np.float64, "z": np.float64},
+                {"ra": np.float64, "dec": np.float64, "z": np.float64, "comoving_distance": np.float64},
                 offset=pix_starts[j, start_vertex],
                 max_size=self.config["chunk_rows"],
             )
@@ -198,14 +208,15 @@ class TXRandomCat(PipelineStage):
                 # Sometimes we don't quite go down to z - deal with that
                 cdf_rand_val = cdf_rand_val.clip(z_cdf_norm.min(), z_cdf_norm.max())
                 z_photo_rand = z_interp_func(cdf_rand_val)
+                distance = pyccl.comoving_radial_distance(cosmo, 1.0 / (1 + z_photo_rand))
 
                 # Save output to the generic non-binned output
                 index = bin_starts[j] + pix_starts[j, i]
-                batch1.write(ra=ra, dec=dec, z=z_photo_rand, bin=bin_index)
+                batch1.write(ra=ra, dec=dec, z=z_photo_rand, comoving_distance=distance, bin=bin_index)
 
                 # Save to the bit that is specific to this bin
                 index = pix_starts[j, i]
-                batch2.write(ra=ra, dec=dec, z=z_photo_rand)
+                batch2.write(ra=ra, dec=dec, z=z_photo_rand, comoving_distance=distance)
 
                 ndone += 1
 

--- a/txpipe/random_cats.py
+++ b/txpipe/random_cats.py
@@ -1,5 +1,12 @@
 from .base_stage import PipelineStage
-from .data_types import MapsFile, YamlFile, RandomsCatalog, TomographyCatalog, HDFFile, FiducialCosmology
+from .data_types import (
+    MapsFile,
+    YamlFile,
+    RandomsCatalog,
+    TomographyCatalog,
+    HDFFile,
+    FiducialCosmology,
+)
 from .utils import choose_pixelization, Splitter
 import numpy as np
 
@@ -171,13 +178,24 @@ class TXRandomCat(PipelineStage):
             # still work.
             batch1 = BatchWriter(
                 group,
-                {"ra": np.float64, "dec": np.float64, "z": np.float64, "comoving_distance": np.float64, "bin": np.int16},
+                {
+                    "ra": np.float64,
+                    "dec": np.float64,
+                    "z": np.float64,
+                    "comoving_distance": np.float64,
+                    "bin": np.int16,
+                },
                 offset=bin_starts[j] + pix_starts[j, start_vertex],
                 max_size=self.config["chunk_rows"],
             )
             batch2 = BatchWriter(
                 subgroup,
-                {"ra": np.float64, "dec": np.float64, "z": np.float64, "comoving_distance": np.float64},
+                {
+                    "ra": np.float64,
+                    "dec": np.float64,
+                    "z": np.float64,
+                    "comoving_distance": np.float64,
+                },
                 offset=pix_starts[j, start_vertex],
                 max_size=self.config["chunk_rows"],
             )
@@ -208,11 +226,19 @@ class TXRandomCat(PipelineStage):
                 # Sometimes we don't quite go down to z - deal with that
                 cdf_rand_val = cdf_rand_val.clip(z_cdf_norm.min(), z_cdf_norm.max())
                 z_photo_rand = z_interp_func(cdf_rand_val)
-                distance = pyccl.comoving_radial_distance(cosmo, 1.0 / (1 + z_photo_rand))
+                distance = pyccl.comoving_radial_distance(
+                    cosmo, 1.0 / (1 + z_photo_rand)
+                )
 
                 # Save output to the generic non-binned output
                 index = bin_starts[j] + pix_starts[j, i]
-                batch1.write(ra=ra, dec=dec, z=z_photo_rand, comoving_distance=distance, bin=bin_index)
+                batch1.write(
+                    ra=ra,
+                    dec=dec,
+                    z=z_photo_rand,
+                    comoving_distance=distance,
+                    bin=bin_index,
+                )
 
                 # Save to the bit that is specific to this bin
                 index = pix_starts[j, i]

--- a/txpipe/twopoint.py
+++ b/txpipe/twopoint.py
@@ -76,6 +76,7 @@ class TXTwoPoint(PipelineStage):
         "patch_dir": "./cache/patches",
         "chunk_rows": 100_000,
         "share_patch_files": False,
+        "metric": "Euclidean",
     }
 
     def run(self):
@@ -88,6 +89,12 @@ class TXTwoPoint(PipelineStage):
 
         # Binning information
         source_list, lens_list = self.read_nbin()
+
+        if self.rank == 0:
+            # This is a workaround for the fact the the ceci config stuff doesn't
+            # quite handle the get method properly.
+            metric = self.config["metric"] if "metric" in self.config else "Euclidean"
+            print(f"Running TreeCorr with metric \"{metric}\"")
 
         # Calculate metadata like the area and related
         # quantities

--- a/txpipe/twopoint.py
+++ b/txpipe/twopoint.py
@@ -2,19 +2,11 @@ from .base_stage import PipelineStage
 from .data_types import (
     HDFFile,
     ShearCatalog,
-    TomographyCatalog,
-    RandomsCatalog,
-    FiducialCosmology,
     SACCFile,
-    PhotozPDFFile,
-    PNGFile,
     TextFile,
 )
-from .utils.calibration_tools import apply_metacal_response, apply_lensfit_calibration
-from .utils.calibration_tools import read_shear_catalog_type
 from .utils.patches import PatchMaker
 import numpy as np
-import random
 import collections
 import sys
 import os
@@ -734,6 +726,7 @@ class TXTwoPoint(PipelineStage):
         meta["mean_e2"] = mean_e2
 
         return meta
+
 
 
 if __name__ == "__main__":

--- a/txpipe/twopoint.py
+++ b/txpipe/twopoint.py
@@ -85,6 +85,10 @@ class TXTwoPoint(PipelineStage):
         if self.rank == 0:
             # This is a workaround for the fact the the ceci config stuff doesn't
             # quite handle the get method properly.
+            # Which metrics are available, and how they are interpreted, depends on
+            # whether a distance is in the catalogs returned in get_shear_catalog
+            # and friends, below. In this base class only the 2D metrics will be
+            # available, but subclasses can specify to load a distance column too.
             metric = self.config["metric"] if "metric" in self.config else "Euclidean"
             print(f"Running TreeCorr with metric \"{metric}\"")
 

--- a/txpipe/utils/patches.py
+++ b/txpipe/utils/patches.py
@@ -235,7 +235,7 @@ class PatchMaker:
         # Get the columns to be used here. Do all the ones
         # that are needed in this case
         cols = {}
-        for col in ["ra", "dec", "g1", "g2", "w"]:
+        for col in ["ra", "dec", "g1", "g2", "w", "r"]:
             # Check if the name of the column is set
             name = cat.config[f"{col}_col"]
             if name != "0":


### PR DESCRIPTION
The "metric" configuration option in TreeCorr was always automatically exposed in TXPipe, since you the config dict is passed on to the treecorr GGCorrelation (etc) initializers. So you can add metric to the config of any subclass and it will work.

This makes it an explicit option in the base class and prints it out.

