### PR TITLE
Handle zero-size catalogs in 2pt stages

### DIFF
--- a/txpipe/extensions/twopoint_scia.py
+++ b/txpipe/extensions/twopoint_scia.py
@@ -353,6 +353,11 @@ class TXSelfCalibrationIA(TXTwoPoint):
             f"Rank {self.rank} calculating shear-position-select bin pair ({i},{j}): {n_i} x {n_j} objects, {n_rand_j} randoms"
         )
 
+        if n_i == 0 or n_j == 0:
+            if self.rank == 0:
+                print("Empty catalog: returning None")
+            return None
+
         ng = treecorr.NGCorrelation(
             self.config, max_rpar=0.0
         )  # The max_rpar = 0.0, is in fact the same as our selection function.
@@ -381,6 +386,11 @@ class TXSelfCalibrationIA(TXTwoPoint):
         print(
             f"Rank {self.rank} calculating shear-position bin pair ({i},{j}): {n_i} x {n_j} objects, {n_rand_j} randoms"
         )
+
+        if n_i == 0 or n_j == 0:
+            if self.rank == 0:
+                print("Empty catalog: returning None")
+            return None
 
         ng = treecorr.NGCorrelation(self.config)
         ng.process(cat_j, cat_i)
@@ -467,6 +477,10 @@ class TXSelfCalibrationIA(TXTwoPoint):
             # First the tracers and generic tags
             tracer1 = f"source_{d.i}"  # if d.corr_type in [XI, GAMMAT,GAMMATS, ] else f'lens_{d.i}'
             tracer2 = f"source_{d.j}"  # if d.corr_type in [XI, GAMMAT, GAMMATS] else f'lens_{d.j}'
+
+            # Skip empty bins
+            if d.object is None:
+                continue
 
             # We build up the comb list to get the covariance of it later
             # in the same order as our data points

--- a/txpipe/twopoint.py
+++ b/txpipe/twopoint.py
@@ -265,6 +265,11 @@ class TXTwoPoint(PipelineStage):
             tracer1 = f"source_{d.i}" if d.corr_type in [XI, GAMMAT] else f"lens_{d.i}"
             tracer2 = f"source_{d.j}" if d.corr_type in [XI] else f"lens_{d.j}"
 
+            # This happens when there is an empty bin. We can't do a covariance
+            # here, or anything useful, really, so we just skip this bin.
+            if d.object is None:
+                continue
+
             # We build up the comb list to get the covariance of it later
             # in the same order as our data points
             comb.append(d.object)
@@ -611,10 +616,16 @@ class TXTwoPoint(PipelineStage):
             cat_j = self.get_shear_catalog(j)
             n_j = cat_j.nobj
 
+
         if self.rank == 0:
             print(
                 f"Calculating shear-shear bin pair ({i},{j}): {n_i} x {n_j} objects using MPI"
             )
+
+        if n_i == 0 or n_j == 0:
+            if self.rank == 0:
+                print("Empty catalog: returning None")
+            return None
 
         gg = treecorr.GGCorrelation(self.config)
         t1 = perf_counter()
@@ -640,6 +651,11 @@ class TXTwoPoint(PipelineStage):
             print(
                 f"Calculating shear-position bin pair ({i},{j}): {n_i} x {n_j} objects, {n_rand_j} randoms"
             )
+
+        if n_i == 0 or n_j == 0:
+            if self.rank == 0:
+                print("Empty catalog: returning None")
+            return None
 
         ng = treecorr.NGCorrelation(self.config)
         t1 = perf_counter()
@@ -681,6 +697,11 @@ class TXTwoPoint(PipelineStage):
             print(
                 f"Calculating position-position bin pair ({i}, {j}): {n_i} x {n_j} objects,  {n_rand_i} x {n_rand_j} randoms"
             )
+
+        if n_i == 0 or n_j == 0:
+            if self.rank == 0:
+                print("Empty catalog: returning None")
+            return None
 
         t1 = perf_counter()
 

--- a/txpipe/twopoint_null_tests.py
+++ b/txpipe/twopoint_null_tests.py
@@ -733,6 +733,10 @@ class TXApertureMass(TXTwoPoint):
             tracer1 = f"source_{d.i}"
             tracer2 = f"source_{d.j}"
 
+            # Skip empty bins
+            if d.object is None:
+                continue
+
             theta = np.exp(d.object.meanlogr)
             weight = d.object.weight
             err = np.sqrt(d.object.mapsq[4])


### PR DESCRIPTION
@marina-ricci spotted that zero-sized catalogs can cause a crash in the 2point stage. This change checks for them and returns None for their `Measurement.object` value. We then have to skip such values later on and not put them in the sacc.

@empEvil could you check that my changes here to your SCIA stage make sense?