### PR TITLE
Implemented TJPCov SSC 

### DIFF
--- a/examples/metadetect/config.yml
+++ b/examples/metadetect/config.yml
@@ -265,6 +265,8 @@ TXRealGaussianCovariance:
     nbins: 10
     pickled_wigner_transform: data/example/inputs/wigner.pkl
 
+TXFourierTJPCovariance:
+    cov_type: ['gauss', 'ssc']
 
 TXJackknifeCenters:
     npatch: 5
@@ -273,7 +275,7 @@ TXJackknifeCenters:
 TXTwoPointFourier:
     flip_g2: True
     ell_min: 30
-    ell_max: 150
+    ell_max: 192 # 3*nside needed for NaMaster
     bandwidth: 20
     cache_dir: ./cache/workspaces
 

--- a/examples/metadetect/pipeline.yml
+++ b/examples/metadetect/pipeline.yml
@@ -73,11 +73,14 @@ stages:
     # The latter two need NaMaster
     # - name: TXRealGaussianCovariance   # Compute covariance of real-space correlations
     # - name: TXFourierGaussianCovariance # Compute the C_ell covariance
+    # - name: TXFourierTJPCovariance # Compute the C_ell covariance
+    #   threads_per_process: 2
 
 
 # modules and packages to import that have pipeline
 # stages defined in them
 modules: txpipe rail
+# modules: txpipe rail tjpcov
 
 # where to find any modules that are not in this repo,
 # and any other code we need.

--- a/txpipe/covariance.py
+++ b/txpipe/covariance.py
@@ -673,6 +673,12 @@ class TXFourierTJPCovariance(PipelineStage):
         assert meta["area_unit"] == "deg^2"
         assert meta["density_unit"] == "arcmin^{-2}"
 
+        # Check that only 'gauss' or 'ssc' are passed to 'cov_type'
+        for ct in self.config['cov_type']:
+            if ct not in ['gauss', 'ssc']:
+                raise ValueError("'cov_type can have only 'gauss' or 'ssc'. " +
+                                 f"'{ct}' passed.")
+
         # get the number of bins from metadata
         nbin_lens = meta["nbin_lens"]
         nbin_source = meta["nbin_source"]

--- a/txpipe/covariance.py
+++ b/txpipe/covariance.py
@@ -656,6 +656,8 @@ class TXFourierTJPCovariance(PipelineStage):
 
     outputs = [
         ("summary_statistics_fourier", SACCFile),
+        ("summary_statistics_fourier_gauss", SACCFile),
+        ("summary_statistics_fourier_ssc", SACCFile),
     ]
 
     config_options = {"galaxy_bias": [0.0], "IA": 0.5, "cache_dir": "",
@@ -781,7 +783,7 @@ class TXFourierTJPCovariance(PipelineStage):
                 cl_sacc2 = cl_sacc.copy()
                 cl_sacc2.add_covariance(c)
                 fname = self.get_output(f"summary_statistics_fourier_{k}")
-                cl_sacc.save_fits(fname, overwrite=True)
+                cl_sacc2.save_fits(fname, overwrite=True)
 
             covmat = sum([c for c in cov.values()])
             cl_sacc.add_covariance(covmat)


### PR DESCRIPTION
This implements the interface with TJPCov to compute the SSC. Now, the stage `TXFourierTJPCovariance` outputs not only `summary_statistics.sacc` but also `summary_statistics_gauss.sacc` and `summary_statistics_ssc.sacc` if they are requested. In order to compute both the Gaussian and the SSC terms, one has to define in the corresponding stage configuration in `config.yml` the following variable `cov_type = ['gauss', 'ssc']`.

The SSC implementation in TJPCov is at the moment under review (https://github.com/LSSTDESC/TJPCov/pull/34), so it might contain some bug.