### PR TITLE
nmtCov: fixed lmax

### DIFF
--- a/examples/metadetect/config.yml
+++ b/examples/metadetect/config.yml
@@ -275,7 +275,7 @@ TXJackknifeCenters:
 TXTwoPointFourier:
     flip_g2: True
     ell_min: 30
-    ell_max: 192 # 3*nside needed for NaMaster
+    ell_max: 100
     bandwidth: 20
     cache_dir: ./cache/workspaces
 


### PR DESCRIPTION
Updated TJPCov version where the lmax issue is fixed (PR https://github.com/LSSTDESC/TJPCov/pull/43). (And updated the config example file to test for it). 