### PR TITLE
Add Continuous Integration running on Nersc

### DIFF
--- a/.github/workflows/ci_nersc.yml
+++ b/.github/workflows/ci_nersc.yml
@@ -1,0 +1,43 @@
+name: Trigger NERSC CI
+
+on: [workflow_dispatch]
+
+env:
+  # URL to source repository on GitHub.
+  GITHUB_SOURCE_REPO: https://github.com/LSSTDESC/TXPipe.git
+  # Branch to work with.
+  GITHUB_SOURCE_BRANCH: master
+
+  # URL to target repository on GitLab and its project number.
+  GITLAB_TARGET_REPO: https://software.nersc.gov/txpipe/txpipe.git
+  GITLAB_TARGET_PROJECT_NUMBER: 472
+
+  # URL to mirror repository on GitLab and its project number.
+  GITLAB_MIRROR_REPO: https://software.nersc.gov/zuntz/mirror-txpipe.git
+  GITLAB_MIRROR_PROJECT_NUMBER: 475
+
+  # URL to status repository on GitLab, its project number, and tag.
+  GITLAB_STATUS_REPO: https://software.nersc.gov/zuntz/status-txpipe.git
+  GITLAB_STATUS_PROJECT_NUMBER: 476
+  GITLAB_STATUS_CONTEXT: NERSC
+  
+jobs:
+  trigger-mirror-repo-ci:
+    runs-on: ubuntu-latest
+    steps:
+      # Trigger mirror repository CI workflow, passing variables as we go.
+      - run: >-
+           curl -X POST --fail 
+           --form "variables[GITLAB_STATUS_REPO]=$GITLAB_STATUS_REPO"
+           --form "variables[GITLAB_TARGET_REPO]=$GITLAB_TARGET_REPO"
+           --form "variables[GITLAB_MIRROR_REPO]=$GITLAB_MIRROR_REPO"
+           --form "variables[GITHUB_SOURCE_REPO]=$GITHUB_SOURCE_REPO"
+           --form "variables[GITHUB_SOURCE_BRANCH]=$GITHUB_SOURCE_BRANCH"
+           --form "variables[GITLAB_TARGET_PROJECT_NUMBER]=$GITLAB_TARGET_PROJECT_NUMBER"
+           --form "variables[GITLAB_MIRROR_PROJECT_NUMBER]=$GITLAB_MIRROR_PROJECT_NUMBER"
+           --form "variables[GITLAB_STATUS_PROJECT_NUMBER]=$GITLAB_STATUS_PROJECT_NUMBER"
+           --form "variables[GITLAB_STATUS_CONTEXT]=$GITLAB_STATUS_CONTEXT"
+           --form "variables[GITHUB_SHA]=${{ github.sha }}"
+           --form token=${{ secrets.MIRROR_TRIGGER_TOKEN }}
+           --form ref=main
+           https://software.nersc.gov/api/v4/projects/$GITLAB_MIRROR_PROJECT_NUMBER/trigger/pipeline

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,40 @@
+# This CI runs on NERSC
+
+variables:
+  # Cori queue submission options.
+  SCHEDULER_PARAMETERS: "-C haswell -M escori -q xfer -N1 -t 01:00:00 -A m1727"
+
+
+# How is this workflow triggered?
+workflow:
+  rules:
+    # Can only be initiated via a trigger token.
+    - if: $CI_PIPELINE_SOURCE == "trigger"
+      when: always
+
+# The CI job.
+example:
+  # Running on Cori.
+  tags: [cori]
+  script:
+    # Script loads desc-python Conda environment and runs tests.
+    - source /global/cfs/cdirs/lsst/groups/WL/users/zuntz/setup-txpipe
+    - curl -O https://portal.nersc.gov/cfs/lsst/txpipe/data/example.tar.gz
+    - tar -zxvf example.tar.gz
+    - tx ceci examples/metadetect/pipeline.yml
+    # Trigger the status repository CI workflow to report results.
+    - >
+      curl -X POST --fail
+      --form "variables[GITLAB_STATUS_REPO]=$GITLAB_STATUS_REPO"
+      --form "variables[GITLAB_TARGET_REPO]=$GITLAB_TARGET_REPO"
+      --form "variables[GITLAB_MIRROR_REPO]=$GITLAB_MIRROR_REPO"
+      --form "variables[GITHUB_SOURCE_REPO]=$GITHUB_SOURCE_REPO"
+      --form "variables[GITHUB_SOURCE_BRANCH]=$GITHUB_SOURCE_BRANCH"
+      --form "variables[GITLAB_TARGET_PROJECT_NUMBER]=$GITLAB_TARGET_PROJECT_NUMBER"
+      --form "variables[GITLAB_MIRROR_PROJECT_NUMBER]=$GITLAB_MIRROR_PROJECT_NUMBER"
+      --form "variables[GITLAB_STATUS_PROJECT_NUMBER]=$GITLAB_STATUS_PROJECT_NUMBER"
+      --form "variables[GITLAB_STATUS_CONTEXT]=$GITLAB_STATUS_CONTEXT"
+      --form "variables[GITHUB_SHA]=$GITHUB_SHA"
+      --form token=$STATUS_TRIGGER_TOKEN
+      --form ref=main
+      https://software.nersc.gov/api/v4/projects/$GITLAB_STATUS_PROJECT_NUMBER/trigger/pipeline


### PR DESCRIPTION
This uses the instructions in https://desc-continuous-integration.readthedocs.io/en/latest/desc/ci_at_nersc.html to try to run a CI test at NERSC.