### PR TITLE
Tjpcov update

### DIFF
--- a/examples/metadetect/config.yml
+++ b/examples/metadetect/config.yml
@@ -266,7 +266,7 @@ TXRealGaussianCovariance:
     pickled_wigner_transform: data/example/inputs/wigner.pkl
 
 TXFourierTJPCovariance:
-    cov_type: ['gauss', 'ssc']
+    cov_type: ["FourierGaussianNmt", "FourierSSCHaloModel"]
 
 TXJackknifeCenters:
     npatch: 5

--- a/txpipe/covariance.py
+++ b/txpipe/covariance.py
@@ -677,6 +677,7 @@ class TXFourierTJPCovariance(PipelineStage):
         nbin_source = meta["nbin_source"]
 
         # set up some config options for TJPCov
+        # tjp_config corresponds to the "tjpcov" section of the input config
         tjp_config = {}
         tjp_config["cov_type"] = self.config['cov_type']
         cl_sacc = self.read_sacc()
@@ -762,11 +763,12 @@ class TXFourierTJPCovariance(PipelineStage):
         # For now, since they're only strings, pass the workspaces even if not
         # requested
         workspaces = self.get_workspaces_dict(cl_sacc, masks_names)
-        tjp_config["workspaces"] =  workspaces
+        cache = {"workspaces":  workspaces}
 
         # Compute the covariance and save it in the cache folder. This will
         # save also the independent terms.
-        calculator = CovarianceCalculator({"tjpcov": tjp_config})
+        calculator = CovarianceCalculator({"tjpcov": tjp_config,
+                                           "cache": cache})
         calculator.create_sacc_cov("summary_statistics_fourier",
                                    save_terms=True)
 

--- a/txpipe/covariance.py
+++ b/txpipe/covariance.py
@@ -659,11 +659,11 @@ class TXFourierTJPCovariance(PipelineStage):
     ]
 
     config_options = {"galaxy_bias": [0.0], "IA": 0.5, "cache_dir": "",
-                      'cov_type': ["CovarianceFourierGaussianNmt",
+                      'cov_type': ["FourierGaussianNmt",
                                    "FourierSSCHaloModel"]}
 
     def run(self):
-        from tjpcov import CovarianceCalculator
+        from tjpcov.covariance_calculator import CovarianceCalculator
         import healpy
         # Read the metadata from earlier in the pipeline
         with self.open_input("tracer_metadata_yml", wrapper=True) as f:
@@ -671,12 +671,6 @@ class TXFourierTJPCovariance(PipelineStage):
         # check the units are what we are expecting
         assert meta["area_unit"] == "deg^2"
         assert meta["density_unit"] == "arcmin^{-2}"
-
-        # Check that only 'gauss' or 'ssc' are passed to 'cov_type'
-        for ct in self.config['cov_type']:
-            if ct not in ['gauss', 'ssc']:
-                raise ValueError("'cov_type can have only 'gauss' or 'ssc'. " +
-                                 f"'{ct}' passed.")
 
         # get the number of bins from metadata
         nbin_lens = meta["nbin_lens"]

--- a/txpipe/covariance.py
+++ b/txpipe/covariance.py
@@ -374,8 +374,9 @@ class TXFourierGaussianCovariance(PipelineStage):
                 s1_s2_2 = s1_s2_2[xi_plus_minus2]
 
             # Use these terms to project the covariance from C_ell to xi(theta)
-            th, cov["final"] = WT.projected_covariance2(
-                l_cl=ell, s1_s2=s1_s2_1, s1_s2_cross=s1_s2_2, cl_cov=cov["final"]
+            th, cov["final"] = WT.projected_covariance(
+                ell_cl=ell, s1_s2=s1_s2_1, s1_s2_cross=s1_s2_2,
+                cl_cov=cov["final"]
             )
 
         # Normalize
@@ -406,7 +407,7 @@ class TXFourierGaussianCovariance(PipelineStage):
 
     def make_wigner_transform(self, meta):
         import threadpoolctl
-        from tjpcov import wigner_transform
+        from tjpcov.wigner_transform import WignerTransform
 
         path = self.config["pickled_wigner_transform"]
         if path:
@@ -427,8 +428,8 @@ class TXFourierGaussianCovariance(PipelineStage):
         num_processes = int(os.environ.get("OMP_NUM_THREADS", 1))
         print("Generating Wigner Transform.")
         with threadpoolctl.threadpool_limits(1):
-            WT = wigner_transform(
-                l=meta["ell"],
+            WT = WignerTransform(
+                ell=meta["ell"],
                 theta=meta["theta"] * d2r,
                 s1_s2=[(2, 2), (2, -2), (0, 2), (2, 0), (0, 0)],
                 ncpu=num_processes,


### PR DESCRIPTION
Updated to the latest version of TJPCov. I have checked that the covariance of the Gaussian sims is recovered by this new version (also the SSC). The plot below shows the logarithmic absolute magnitude relative difference between the new and old NaMaster Gaussian covariance for the Gaussian sims with nside 4096.

```
max abs rdev diag 5.073366493579812e-07
max abs rdev 1-off diag 0.00029870120325070637
max abs rdev 2-off diag 1.4045054967715132e-05
max abs rdev 0.1497571259501531
number of elements with abs rdev > 1e-3 42
Compare chi2
10889.579466013645
10889.579788057401
```
![image](https://user-images.githubusercontent.com/17812754/205612785-ffc3f8da-b8d0-4a59-a29e-90cb9987827d.png)

I have also checked that the refactored `wigner_transform.py` does not break the Real space covariance:
```
xi diff 2.458415715353579e-06
max abs rdev diag 3.0167256048763136e-07
max abs rdev 1-off diag 4.964438110466318e-05
max abs rdev 2-off diag 4.9329188987368155e-05
max abs rdev 0.4280426719575654
number of elements with abs rdev > 1e-3 362
number of elements with abs rdev > 1e-2 36
Compare chi2
4293.008339413925
4293.008400966504
```
![image](https://user-images.githubusercontent.com/17812754/205616352-bfa6bcbb-4d3f-4837-b78b-24af9ab8921b.png)
