### PR TITLE
Use the pypi version of TJPCov

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,9 +5,6 @@
 [submodule "WLMassMap"]
 	path = submodules/WLMassMap
 	url = https://github.com/LSSTDESC/WLMassMap
-[submodule "submodules/TJPCov"]
-	path = submodules/TJPCov
-	url = https://github.com/LSSTDESC/TJPCov
 [submodule "submodules/RAIL"]
 	path = submodules/RAIL
 	url = https://github.com/LSSTDESC/RAIL

--- a/conda.txt
+++ b/conda.txt
@@ -17,3 +17,4 @@ mpich
 h5py=*=mpi_mpich_*
 cosmosis-standalone
 tables-io
+tjpcov

--- a/conda.txt
+++ b/conda.txt
@@ -17,4 +17,3 @@ mpich
 h5py=*=mpi_mpich_*
 cosmosis-standalone
 tables-io
-tjpcov

--- a/examples/2.2i/pipeline.yml
+++ b/examples/2.2i/pipeline.yml
@@ -18,7 +18,6 @@ modules: txpipe
 # and any other code we need.
 python_paths:
     - submodules/WLMassMap/python/desc/
-    - submodules/TJPCov
     - submodules/FlexZPipe
 
 stages:

--- a/examples/2.2i/pipeline_1tract.yml
+++ b/examples/2.2i/pipeline_1tract.yml
@@ -18,7 +18,6 @@ modules: txpipe
 # and any other code we need.
 python_paths:
     - submodules/WLMassMap/python/desc/
-    - submodules/TJPCov
     - submodules/FlexZPipe
 
 stages:

--- a/examples/cosmodc2/pipeline.yml
+++ b/examples/cosmodc2/pipeline.yml
@@ -10,7 +10,6 @@ modules: txpipe
 
 python_paths:
     - submodules/WLMassMap/python/desc/
-    - submodules/TJPCov
     - submodules/FlexZPipe
 
 stages:

--- a/examples/cosmodc2/pipeline_redmagic.yml
+++ b/examples/cosmodc2/pipeline_redmagic.yml
@@ -10,7 +10,6 @@ modules: txpipe
 
 python_paths:
     - submodules/WLMassMap/python/desc/
-    - submodules/TJPCov
     - submodules/FlexZPipe
 
 stages:

--- a/examples/cosmodc2/pipeline_redmagic_full.yml
+++ b/examples/cosmodc2/pipeline_redmagic_full.yml
@@ -10,7 +10,6 @@ modules: txpipe
 
 python_paths:
     - submodules/WLMassMap/python/desc/
-    - submodules/TJPCov
     - submodules/FlexZPipe
 
 stages:

--- a/examples/cosmodc2/pipeline_redmagic_no_shape_noise.yml
+++ b/examples/cosmodc2/pipeline_redmagic_no_shape_noise.yml
@@ -10,7 +10,6 @@ modules: txpipe
 
 python_paths:
     - submodules/WLMassMap/python/desc/
-    - submodules/TJPCov
     - submodules/FlexZPipe
 
 stages:

--- a/examples/cosmodc2/pipeline_redmagic_no_shape_noise_full.yml
+++ b/examples/cosmodc2/pipeline_redmagic_no_shape_noise_full.yml
@@ -10,7 +10,6 @@ modules: txpipe
 
 python_paths:
     - submodules/WLMassMap/python/desc/
-    - submodules/TJPCov
     - submodules/FlexZPipe
 
 stages:

--- a/examples/gaussian_sims/pipeline_gaussian_sims.yml
+++ b/examples/gaussian_sims/pipeline_gaussian_sims.yml
@@ -10,7 +10,6 @@ modules: txpipe
 
 python_paths:
     - submodules/WLMassMap/python/desc/
-    - submodules/TJPCov
     - submodules/FlexZPipe
 
 stages:

--- a/examples/lensfit/pipeline.yml
+++ b/examples/lensfit/pipeline.yml
@@ -72,7 +72,6 @@ modules: txpipe rail.stages
 # and any other code we need.
 python_paths:
     - submodules/WLMassMap/python/desc/
-    - submodules/TJPCov
 
 # configuration settings
 config: examples/lensfit/config.yml

--- a/examples/metacal/pipeline.yml
+++ b/examples/metacal/pipeline.yml
@@ -78,7 +78,6 @@ modules: txpipe rail.stages
 # and any other code we need.
 python_paths:
     - submodules/WLMassMap/python/desc/
-    - submodules/TJPCov
 
 # Where to put outputs
 output_dir: data/example/outputs

--- a/examples/metadetect/pipeline.yml
+++ b/examples/metadetect/pipeline.yml
@@ -85,7 +85,6 @@ modules: txpipe rail.stages
 # and any other code we need.
 python_paths:
     - submodules/WLMassMap/python/desc/
-    - submodules/TJPCov
 
 # Where to put outputs
 output_dir: data/example/outputs_metadetect

--- a/examples/randoms/pipeline_randomsonly.yml
+++ b/examples/randoms/pipeline_randomsonly.yml
@@ -15,7 +15,6 @@ modules: txpipe rail.stages
 # and any other code we need.
 python_paths:
     - submodules/WLMassMap/python/desc/
-    - submodules/TJPCov
 
 # Where to put outputs
 output_dir: data/example/outputs_randoms

--- a/examples/redmagic/pipeline.yml
+++ b/examples/redmagic/pipeline.yml
@@ -67,7 +67,6 @@ modules: txpipe
 # and any other code we need.
 python_paths:
     - submodules/WLMassMap/python/desc/
-    - submodules/TJPCov
 
 # configuration settings
 config: examples/redmagic/config.yml

--- a/examples/redmagic/pipeline_complete.yml
+++ b/examples/redmagic/pipeline_complete.yml
@@ -65,7 +65,6 @@ modules: txpipe
 # and any other code we need.
 python_paths:
     - submodules/WLMassMap/python/desc/
-    - submodules/TJPCov
     - submodules/FlexZPipe
 
 # configuration settings

--- a/examples/skysim/pipeline.yml
+++ b/examples/skysim/pipeline.yml
@@ -10,7 +10,6 @@ modules: txpipe
 
 python_paths:
     - submodules/WLMassMap/python/desc/
-    - submodules/TJPCov
     - submodules/FlexZPipe
 
 stages:

--- a/examples/star-challenge/sample-for-pz_full.yml
+++ b/examples/star-challenge/sample-for-pz_full.yml
@@ -12,7 +12,6 @@ modules: txpipe
 # and any other code we need.
 python_paths:
     - submodules/WLMassMap/python/desc/
-    - submodules/TJPCov
     - submodules/FlexZPipe
     - submodules/RAIL
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,3 +29,4 @@ git+https://github.com/jlvdb/hyperbolic
 pzflow
 tables-io
 healpix
+tjpcov

--- a/txpipe/covariance.py
+++ b/txpipe/covariance.py
@@ -259,7 +259,7 @@ class TXFourierGaussianCovariance(PipelineStage):
         WT=None,
     ):
         import pyccl as ccl
-        from tjpcov import bin_cov
+        from tjpcov.wigner_transform import bin_cov
 
         cl = {}
 
@@ -445,7 +445,7 @@ class TXFourierGaussianCovariance(PipelineStage):
 
     # compute all the covariances and then combine them into one single giant matrix
     def compute_covariance(self, cosmo, meta, two_point_data):
-        from tjpcov import bin_cov
+        from tjpcov.wigner_transform import bin_cov
 
         ccl_tracers, tracer_Noise = self.get_tracer_info(
             cosmo, meta, two_point_data=two_point_data

--- a/txpipe/covariance_nmt.py
+++ b/txpipe/covariance_nmt.py
@@ -406,7 +406,7 @@ class TXFourierNamasterCovariance(PipelineStage):
         WT=None,
     ):
         import pyccl as ccl
-        from tjpcov import bin_cov
+        from tjpcov.wigner_transform import bin_cov
         import pymaster as nmt
         import scipy
 
@@ -892,7 +892,7 @@ class TXFourierNamasterCovariance(PipelineStage):
 
     # compute all the covariances and then combine them into one single giant matrix
     def compute_covariance(self, cosmo, meta, two_point_data, diclist):
-        from tjpcov import bin_cov
+        from tjpcov.wigner_transform import bin_cov
 
         ccl_tracers, tracer_Noise = self.get_tracer_info(
             cosmo, meta, two_point_data=two_point_data

--- a/txpipe/mapping/basic_maps.py
+++ b/txpipe/mapping/basic_maps.py
@@ -46,9 +46,9 @@ class Mapper:
         npix = self.pixel_scheme.npix
         do_lens = self.do_lens
         do_g = self.do_g
-        
+
         n = len(data["ra"])
-        
+
         # Get pixel indices
         pix_nums = self.pixel_scheme.ang2pix(data["ra"], data["dec"])
 
@@ -61,7 +61,7 @@ class Mapper:
         if do_lens:
             lens_weights = data["lens_weight"]
             lens_bins = data["lens_bin"]
-        
+
         for i in range(n):
             p = pix_nums[i]
 
@@ -110,7 +110,7 @@ class Mapper:
         # mask is one where *any* of the maps are valid.
         # this lets us maintain a single pixelization for
         # everything.
-        mask = np.zeros(self.pixel_scheme.npix, dtype=np.bool)
+        mask = np.zeros(self.pixel_scheme.npix, dtype=bool)
 
         is_master = (comm is None) or (comm.Get_rank() == 0)
 

--- a/txpipe/random_cats.py
+++ b/txpipe/random_cats.py
@@ -169,7 +169,7 @@ class TXRandomCat(PipelineStage):
 
             ### Make cdf and normalise
             z_cdf = np.cumsum(n_hist)
-            z_cdf_norm = z_cdf / np.float(max(z_cdf))
+            z_cdf_norm = z_cdf / float(max(z_cdf))
 
             subgroup = subgroups[j]
             # Generate the random points in each pixel
@@ -257,10 +257,10 @@ class TXRandomCat(PipelineStage):
 
                 #pixel id for each random objects in this chunk
                 pix_catalog = np.repeat(pixel[start_vertex:end_vertex], numbers[j,:][start_vertex:end_vertex])
-                
-                #generate a random location within the pixel using healpix 
+
+                #generate a random location within the pixel using healpix
                 ra, dec = healpix.randang(nside, pix_catalog, lonlat=True)
-                
+
                 N = len(pix_catalog)
                 bin_index = np.repeat(j, N)
 


### PR DESCRIPTION
I have removed the `submodules/TJPCov` dependency and used the pypi version of TJPCov. I have also modified a few imports that will be broken in tjpcov-0.1.2 (i.e. after merging https://github.com/LSSTDESC/TJPCov/pull/62). The new way is compatible with current version of TJPCov, too.

Edit: extra commits replacing `np.bool` by `bool` and `np.float` by `float` have been pushed to avoid the tests failing due to numpy deprecations. Would have it been better to change `np.float` to `np.float64`?