### PR TITLE
metacal fix

### DIFF
--- a/examples/desy3/config.yml
+++ b/examples/desy3/config.yml
@@ -4,7 +4,7 @@ global:
     # This is read by many stages that read complete
     # catalog data, and tells them how many rows to read
     # at once
-    chunk_rows: 100000
+    chunk_rows: 1000000000
     # These mapping options are also read by a range of stages
     pixelization: healpix
     nside: 128
@@ -56,10 +56,11 @@ TXSourceSelectorMetacal:
     bands: riz #used for selection
     T_cut: 0.5
     s2n_cut: 10.0
-    max_rows: 1000
+    max_rows: 10000000000
     delta_gamma: 0.02
-    source_zbin_edges: [0.2, 0.43, 0.63, 0.90, 1.30]
+    source_zbin_edges: [0.0, 0.2, 0.4, 0.6, 0.8]
     shear_prefix: mcal_
+    resp_mean_diag : True
 
 TXSourceSelectorLensfit:
     bands: ri #used for selection

--- a/examples/desy3/pipeline.yml
+++ b/examples/desy3/pipeline.yml
@@ -2,8 +2,8 @@
 # Stages to run
 stages:
 
-    #- name: TXSourceSelectorLensfit # select and split objects into source bins
-    #- name: TXShearCalibration   # Calibrate and split the source sample tomographically
+    - name: TXSourceSelectorMetacal # select and split objects into source bins
+    - name: TXShearCalibration   # Calibrate and split the source sample tomographically
     #- name: TXPhotozPlots
     #- name: TXPhotozSourceStack 
     #- name: TXTruthLensCatalogSplitter
@@ -39,12 +39,12 @@ stages:
       #threads_per_process: 2
     #- name: TXGammaTRandoms      # Compute and plot gamma_t around randoms
       #threads_per_process: 2
-    - name: TXRoweStatistics     # Compute and plot Rowe statistics
+    #- name: TXRoweStatistics     # Compute and plot Rowe statistics
     #  threads_per_process: 128
     #- name: TXFocalPlanePlot      # mean PSF ellipticity and mean residual on the focal plane 
       #- name: TXGalaxyStarDensity  # Compute and plot the star-galaxy density cross-correlation
       #- name: TXGalaxyStarShear    # Compute and plot the star-galaxy shear cross-correlation
-    - name: TXPSFDiagnostics     # Compute and plots other PSF diagnostics
+    #- name: TXPSFDiagnostics     # Compute and plots other PSF diagnostics
     #- name: TXBrighterFatterPlot # Make plots tracking the brighter-fatter effect
     #- name: TXConvergenceMaps    # Make convergence kappa maps from g1, g2 maps #ERROR: WLMASSMAP
     #- name: TXConvergenceMapPlots # Plot the convergence map
@@ -88,8 +88,9 @@ config: examples/desy3/config.yml
 
 # These are overall inputs to the whole pipeline, not generated within it
 inputs:
-    shear_catalog:  
+    shear_catalog: //global/cfs/cdirs/lsst/groups/WL/projects/txpipe-sys-tests/des-y3/shear_catalog_desy3_unmasked_withfakez_v2.h5
     photometry_catalog: 
+    #shear_tomography_catalog: /global/cfs/cdirs/desc-wl/projects/txpipe-sys-tests/des-y3/shear_tomography_desy3_unmasked_test.h5
     lens_tomography_catalog: /global/cfs/cdirs/lsst/groups/WL/projects/txpipe-sys-tests/des-y1/lens_tomography_catalog_desy1_RM.h5
     lens_photoz_stack: 
     mask: /global/cfs/cdirs/lsst/groups/WL/projects/txpipe-sys-tests/des-y1/mask_desy1.h5
@@ -101,7 +102,7 @@ inputs:
 
 # if supported by the launcher, restart the pipeline where it left off
 # if interrupted
-resume: True
+resume: False
 
 # where to put output logs for individual stages
 log_dir: data/desy3/logs

--- a/txpipe/source_selector.py
+++ b/txpipe/source_selector.py
@@ -131,7 +131,6 @@ class TXSourceSelectorBase(PipelineStage):
         "chunk_rows": 10000,
         "source_zbin_edges": [float],
         "random_seed": 42,
-        "resp_mean_diag": False
     }
 
     def run(self):
@@ -462,7 +461,7 @@ class TXSourceSelectorMetacal(TXSourceSelectorBase):
     config_options = {
         **TXSourceSelectorBase.config_options,
         "delta_gamma": float,
-        "resp_mean_diag": bool 
+        "resp_mean_diag": False
     }
 
 
@@ -490,7 +489,7 @@ class TXSourceSelectorMetacal(TXSourceSelectorBase):
             shear_cols += ["redshift_true"]
 
         chunk_rows = self.config["chunk_rows"]
-        return self.iterate_hdf("shear_catalog", "shear", shear_cols, chunk_rows)
+        return self.iterate_hdf("shear_catalog", "shear", shear_cols, chunk_rows, longest=True)
 
     def setup_output(self):
         """

--- a/txpipe/source_selector.py
+++ b/txpipe/source_selector.py
@@ -461,7 +461,7 @@ class TXSourceSelectorMetacal(TXSourceSelectorBase):
     config_options = {
         **TXSourceSelectorBase.config_options,
         "delta_gamma": float,
-        "resp_mean_diag": False
+        "use_mean_diag": False
     }
 
 
@@ -489,7 +489,7 @@ class TXSourceSelectorMetacal(TXSourceSelectorBase):
             shear_cols += ["redshift_true"]
 
         chunk_rows = self.config["chunk_rows"]
-        return self.iterate_hdf("shear_catalog", "shear", shear_cols, chunk_rows, longest=True)
+        return self.iterate_hdf("shear_catalog", "shear", shear_cols, chunk_rows)#, longest=True)
 
     def setup_output(self):
         """
@@ -520,11 +520,11 @@ class TXSourceSelectorMetacal(TXSourceSelectorBase):
 
     def setup_response_calculators(self, nbin_source):
         delta_gamma = self.config["delta_gamma"]
-        resp_mean_diag = self.config["resp_mean_diag"]
+        use_diagonal_response = self.config["use_diagonal_response"]
         calculators = [
-            MetacalCalculator(self.select, delta_gamma,resp_mean_diag) for i in range(nbin_source)
+            MetacalCalculator(self.select, delta_gamma,use_diagonal_response) for i in range(nbin_source)
         ]
-        calculators.append(MetacalCalculator(self.select_2d, delta_gamma,resp_mean_diag))
+        calculators.append(MetacalCalculator(self.select_2d, delta_gamma,use_diagonal_response))
         return calculators
 
     def write_tomography(self, outfile, start, end, source_bin, R):

--- a/txpipe/source_selector.py
+++ b/txpipe/source_selector.py
@@ -277,7 +277,7 @@ class TXSourceSelectorBase(PipelineStage):
         # This calibrator refers to self.select_2d
         calculators[-1].add_data(data)
 
-        return tomo_bin[tomo_bin>=0], R[tomo_bin>=0], counts
+        return tomo_bin, R, counts
 
     def compute_per_object_response(self, data):
         # The default implementation has no per-object response
@@ -489,7 +489,7 @@ class TXSourceSelectorMetacal(TXSourceSelectorBase):
             shear_cols += ["redshift_true"]
 
         chunk_rows = self.config["chunk_rows"]
-        return self.iterate_hdf("shear_catalog", "shear", shear_cols, chunk_rows)#, longest=True)
+        return self.iterate_hdf("shear_catalog", "shear", shear_cols, chunk_rows)
 
     def setup_output(self):
         """

--- a/txpipe/source_selector.py
+++ b/txpipe/source_selector.py
@@ -461,7 +461,7 @@ class TXSourceSelectorMetacal(TXSourceSelectorBase):
     config_options = {
         **TXSourceSelectorBase.config_options,
         "delta_gamma": float,
-        "use_mean_diag": False
+        "use_diagonal_response": False
     }
 
 


### PR DESCRIPTION
This pull request fixes issues with the selection part of the DES-Y3 metacal response.
It also adds the option of using the diagonal approximation R==(R[0,0]+R[1,1])/2 (as used in DES-Y3).
The output responses have been cross-checked against the official calibration code and also table 4 of 2105.13541. 