### PR TITLE
More configurable TXTwoPointFourier

### DIFF
--- a/examples/metacal/config.yml
+++ b/examples/metacal/config.yml
@@ -289,6 +289,10 @@ TXTwoPointFourier:
     ell_max: 150
     bandwidth: 20
     cache_dir: ./cache/workspaces
+    do_shear_shear: False
+    do_shear_pos: False
+    do_pos_pos: True
+    compute_theory: False
 
 TXSimpleMask:
     depth_cut : 23.5

--- a/examples/metacal/config.yml
+++ b/examples/metacal/config.yml
@@ -289,10 +289,10 @@ TXTwoPointFourier:
     ell_max: 150
     bandwidth: 20
     cache_dir: ./cache/workspaces
-    do_shear_shear: False
-    do_shear_pos: False
+    do_shear_shear: True
+    do_shear_pos: True
     do_pos_pos: True
-    compute_theory: False
+    compute_theory: True
 
 TXSimpleMask:
     depth_cut : 23.5

--- a/examples/metadetect/config.yml
+++ b/examples/metadetect/config.yml
@@ -297,6 +297,10 @@ TXTwoPointFourier:
     ell_max: 100
     bandwidth: 20
     cache_dir: ./cache/workspaces
+    do_shear_shear: True
+    do_shear_pos: True
+    do_pos_pos: True
+    compute_theory: True
 
 TXSimpleMaskFrac:
     supreme_map_file: data/example/inputs/supreme_dc2_dr6d_v2_g_nexp_sum_1deg2.hs

--- a/txpipe/data_types/types.py
+++ b/txpipe/data_types/types.py
@@ -197,9 +197,9 @@ class MapsFile(HDFFile):
             raise ValueError(f"Unknown map pixelization type {pixelization}")
         return m
 
-    def read_mask(self):
+    def read_mask(self, thresh=0):
         mask = self.read_map("mask")
-        mask[mask < 0] = 0
+        mask[mask <= thresh] = 0
         return mask
 
     def write_map(self, map_name, pixel, value, metadata):

--- a/txpipe/maps.py
+++ b/txpipe/maps.py
@@ -424,18 +424,16 @@ class TXDensityMaps(PipelineStage):
     outputs = [
         ("density_maps", MapsFile),
     ]
+    config_options = {
+        "mask_threshold": 0.0
+    }
 
     def run(self):
         import healpy
 
-        #check if mask threshold provided in config (assume 0 if not)
-        try:
-            thresh = self.config["mask_threshold"]
-        except KeyError:
-            thresh = 0
         # Read the mask and set all pixels below the threshold to 0
         with self.open_input("mask", wrapper=True) as f:
-            mask = f.read_mask(thresh=thresh)
+            mask = f.read_mask(thresh=self.config["mask_threshold"])
         
         #identify unmasked pixels
         pix_keep = mask > 0.

--- a/txpipe/maps.py
+++ b/txpipe/maps.py
@@ -428,17 +428,16 @@ class TXDensityMaps(PipelineStage):
     def run(self):
         import healpy
 
-        # Read the mask
+        #check if mask threshold provided in config (assume 0 if not)
+        try:
+            thresh = self.config["mask_threshold"]
+        except KeyError:
+            thresh = 0
+        # Read the mask and set all pixels below the threshold to 0
         with self.open_input("mask", wrapper=True) as f:
-            mask = f.read_mask(thresh=self.config["mask_threshold"])
-        '''    mask = f.read_map("mask")
-
-        # set unseen pixels to weight zero
-        mask[mask == healpy.UNSEEN] = 0
-        mask[np.isnan(mask)] = 0
-        mask = mask.flatten()
-        #identify pixels to keep (i.e. mask value above specified threshold)
-        '''
+            mask = f.read_mask(thresh=thresh)
+        
+        #identify unmasked pixels
         pix_keep = mask > 0.
         pix = np.where(pix_keep)[0]
 

--- a/txpipe/maps.py
+++ b/txpipe/maps.py
@@ -424,23 +424,22 @@ class TXDensityMaps(PipelineStage):
     outputs = [
         ("density_maps", MapsFile),
     ]
-    config_options = {
-        'weight_thresh': 0.
-    }
 
     def run(self):
         import healpy
 
         # Read the mask
         with self.open_input("mask", wrapper=True) as f:
-            mask = f.read_map("mask")
+            mask = f.read_mask(thresh=self.config["mask_threshold"])
+        '''    mask = f.read_map("mask")
 
         # set unseen pixels to weight zero
         mask[mask == healpy.UNSEEN] = 0
         mask[np.isnan(mask)] = 0
         mask = mask.flatten()
         #identify pixels to keep (i.e. mask value above specified threshold)
-        pix_keep = mask > self.config['weight_thresh']
+        '''
+        pix_keep = mask > 0.
         pix = np.where(pix_keep)[0]
 
         # Read the count maps

--- a/txpipe/twopoint_fourier.py
+++ b/txpipe/twopoint_fourier.py
@@ -125,7 +125,7 @@ class TXTwoPointFourier(PipelineStage):
             with self.open_input("fiducial_cosmology", wrapper=True) as f:
                 cosmo = f.to_ccl()
 
-            theory_ell = np.unique(np.geomspace(1, 3000, 100).astype(int))
+            theory_ell = np.unique(np.geomspace(self.config["ell_min"], self.config["ell_max"], 100).astype(int))
             theory_sacc = theory_3x2pt(cosmo,
                                     tracer_sacc,
                                     bias=self.config["b0"],

--- a/txpipe/twopoint_fourier.py
+++ b/txpipe/twopoint_fourier.py
@@ -422,7 +422,10 @@ class TXTwoPointFourier(PipelineStage):
 
         # The density fields share a mask, so just use the field
         # object for the first one.
-        density_field = (density_weight, density_fields[0])
+        try:
+            density_field = (density_weight, density_fields[0])
+        except IndexError:
+            density_field = (density_weight, None)
 
         spaces = {}
 

--- a/txpipe/twopoint_fourier.py
+++ b/txpipe/twopoint_fourier.py
@@ -140,14 +140,6 @@ class TXTwoPointFourier(PipelineStage):
         # This will be used for parallelization.
         calcs = self.select_calculations(nbin_source, nbin_lens)
 
-        if not self.config["analytic_noise"]:
-            # Load in the per-bin auto-correlation noise levels and
-            # mean response values
-            # Note - this is currently unused, because we are using the noise
-            # maps instead of an analytic form, but that could change later
-            # so I will leave this here.
-            tomo_info = self.load_tomographic_quantities(nbin_source, nbin_lens, f_sky)
-
         # Binning scheme, currently chosen from the geometry.
         # TODO: set ell binning from config
         ell_bins = self.choose_ell_bins(pixel_scheme, f_sky)


### PR DESCRIPTION
Users can now specify which components of 3x2pt analysis to run in TXTwoPointFourier. Computation of the theory power spectra has also been made optional. Certain inputs (fiducial_cosmology, source_noise_maps, lens_noise_maps, density_maps, source_maps) are now also optional depending on which analyses the user wants to run. 

Treatment of the survey mask has also been modified to account for cases where the mask is not binary. Users can now also specify a global config parameter, "mask_threshold", so that whenever the mask is read all pixels less than or equal to this value are automatically set to zero.

Tested with example 'metacal' and 'metadetect' pipelines, using all possible combinations of POS-POS, SHEAR-POS  and SHEAR-SHEAR.