### PR TITLE
change macos version in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -281,7 +281,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-12]
         include:
           - os: ubuntu-latest
             INSTALL_DEPS: sudo apt-get update && sudo apt-get -y install wget

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -285,7 +285,7 @@ jobs:
         include:
           - os: ubuntu-latest
             INSTALL_DEPS: sudo apt-get update && sudo apt-get -y install wget
-          - os: macos-latest
+          - os: macos-12
             INSTALL_DEPS: brew update-reset && brew install wget
     steps:
     - name: Checkout repository


### PR DESCRIPTION
changing mac OS version in CI installation test

macos-latest now defaults to M1 which TXPipe does not yet officially support. Previously macos-latest pointed to macos-12 so fixing to that temporarily until we can get M1 installation set up