### PR TITLE
Add missing import for cluster notebook to run

### DIFF
--- a/txpipe/extensions/clmm/__init__.py
+++ b/txpipe/extensions/clmm/__init__.py
@@ -1,4 +1,4 @@
 #from .ingest import *
-from .select import CLClusterShearCatalogs
+from .select import CLClusterShearCatalogs, CombinedClusterCatalog
 from .bin_cluster import CLClusterBinningRedshiftRichness
 from .rlens import TXTwoPointRLens


### PR DESCRIPTION
Added `CombinedClusterCatalog` to the imports in txpipe/extensions/clmm/_init_.py for `txpipe_cluster_background.ipynb` to run properly.