### PR TITLE
Move parallel statistics imports inside functions

### DIFF
--- a/txpipe/diagnostics.py
+++ b/txpipe/diagnostics.py
@@ -1,6 +1,5 @@
 from .base_stage import PipelineStage
 from .data_types import Directory, ShearCatalog, HDFFile, PNGFile, TomographyCatalog, TextFile
-from parallel_statistics import ParallelMeanVariance, ParallelHistogram
 from .utils.calibrators import Calibrator
 from .utils.calibration_tools import (
     calculate_selection_response,
@@ -667,6 +666,7 @@ class TXSourceDiagnosticPlots(PipelineStage):
         fig.close()
         
     def plot_g_histogram(self):
+        from parallel_statistics import ParallelHistogram
         print("plotting histogram")
         import matplotlib.pyplot as plt
         from scipy import stats
@@ -762,6 +762,7 @@ class TXSourceDiagnosticPlots(PipelineStage):
                 plt.legend()
 
     def plot_snr_histogram(self):
+        from parallel_statistics import ParallelMeanVariance
         print("plotting snr histogram")
         import matplotlib.pyplot as plt
 

--- a/txpipe/mapping/basic_maps.py
+++ b/txpipe/mapping/basic_maps.py
@@ -1,5 +1,4 @@
 from ..utils import import_dask
-from parallel_statistics import ParallelSum
 
 import numpy as np
 

--- a/txpipe/mapping/dr1.py
+++ b/txpipe/mapping/dr1.py
@@ -1,6 +1,5 @@
 import numpy as np
 from ..utils import import_dask
-from parallel_statistics import ParallelMeanVariance
 
 def make_dask_bright_object_map(ra, dec, mag, extended, threshold, pixel_scheme):
     """

--- a/txpipe/psf_diagnostics.py
+++ b/txpipe/psf_diagnostics.py
@@ -10,7 +10,6 @@ from .data_types import (
     TextFile
 
 )
-from parallel_statistics import ParallelHistogram, ParallelMeanVariance
 import numpy as np
 import sys
 import os
@@ -126,6 +125,7 @@ class TXPSFDiagnostics(PipelineStage):
 
     def plot_histogram(self, function, output_name, xlabel, edges):
         import matplotlib.pyplot as plt
+        from parallel_statistics import ParallelHistogram, ParallelMeanVariance
 
         print(f"Plotting {output_name}")
         counters = {s: ParallelHistogram(edges) for s in STAR_TYPES}

--- a/txpipe/utils/calibration_tools.py
+++ b/txpipe/utils/calibration_tools.py
@@ -1,5 +1,4 @@
 import numpy as np
-from parallel_statistics import ParallelMeanVariance, ParallelMean
 from .mpi_utils import in_place_reduce
 
 
@@ -171,6 +170,7 @@ class MetacalCalculator(CalibrationCalculator):
         delta_gamma: float
             The difference in applied g between 1p and 1m metacal variants
         """
+        from parallel_statistics import ParallelMean
         self.selector = selector
         self.count = 0
         self.sum_weights    = 0
@@ -356,6 +356,7 @@ class MetaDetectCalculator(CalibrationCalculator):
         delta_gamma: float
             The difference in applied g between 1p and 1m metacal variants
         """
+        from parallel_statistics import ParallelMean
         self.selector = selector
         self.delta_gamma = delta_gamma
         self.mean_e = ParallelMean(size=10)
@@ -482,6 +483,7 @@ class LensfitCalculator(CalibrationCalculator):
         selector: function
             Function that selects objects
         """
+        from parallel_statistics import ParallelMean
         self.selector = selector
         # Create a set of calculators that will calculate (in parallel)
         # the three quantities we need to compute the overall calibration
@@ -640,6 +642,7 @@ class HSCCalculator(CalibrationCalculator):
         selector: function
             Function that selects objects
         """
+        from parallel_statistics import ParallelMean
         self.selector = selector
         # Create a set of calculators that will calculate (in parallel)
         # the three quantities we need to compute the overall calibration
@@ -859,6 +862,7 @@ class MeanShearInBins:
         shear_catalog_type="metacal",
         psf_unit_conv= False
     ):
+        from parallel_statistics import ParallelMeanVariance, ParallelMean
         self.x_name = x_name
         self.limits = limits
         self.delta_gamma = delta_gamma

--- a/txpipe/utils/number_density_stats.py
+++ b/txpipe/utils/number_density_stats.py
@@ -1,9 +1,9 @@
-from parallel_statistics import ParallelMeanVariance
 import numpy as np
 
 
 class SourceNumberDensityStats:
     def __init__(self, nbin_source, shear_type, comm=None):
+        from parallel_statistics import ParallelMeanVariance
         self.nbin_source = nbin_source
         self.comm = comm
         self.shear_type = shear_type


### PR DESCRIPTION
This stops you from needing parallel_statistics in the launching environment, which is needed to use the lsst environment to do ingestion at NERSC.

Some older imports were not needed at all.