### PR TITLE
Use spectroscopic RAIL file instead of old calib table

### DIFF
--- a/txpipe/binning/random_forest.py
+++ b/txpipe/binning/random_forest.py
@@ -1,7 +1,16 @@
 import numpy as np
 
+def read_training_data(spec_file, bands, spec_mag_column_format, spec_redshift_column):
+        fmt = spec_mag_column_format
+        zfmt = spec_redshift_column
+        training_data = {}
+        training_data["sz"] = spec_file[zfmt][:]
+        for band in bands:
+            col = spec_file[fmt.format(band=band)][:]
+            training_data[band] = col
+        return training_data
 
-def build_tomographic_classifier(bands, training_file, bin_edges, random_seed, comm):
+def build_tomographic_classifier(bands, training_data_table, bin_edges, random_seed, comm):
     # Load the training data
     # Build the SOM from the training data
     from astropy.table import Table
@@ -15,9 +24,6 @@ def build_tomographic_classifier(bands, training_file, bin_edges, random_seed, c
         classifier = comm.bcast(None)
         features = comm.bcast(None)
         return classifier, features
-
-    # Load the training data
-    training_data_table = Table.read(training_file, format="ascii")
 
     # Pull out the appropriate columns and combinations of the data
     print(f"Using these bands to train the tomography selector: {bands}")

--- a/txpipe/lens_selector.py
+++ b/txpipe/lens_selector.py
@@ -10,7 +10,7 @@ from .data_types import (
     MapsFile,
 )
 from .utils import LensNumberDensityStats, Splitter, rename_iterated
-from .binning import build_tomographic_classifier, apply_classifier
+from .binning import build_tomographic_classifier, apply_classifier, read_training_data
 import numpy as np
 import warnings
 
@@ -493,7 +493,7 @@ class TXRandomForestLensSelector(TXBaseLensSelector):
     name = "TXRandomForestLensSelector"
     inputs = [
         ("photometry_catalog", PhotometryCatalog),
-        ("calibration_table", TextFile),
+        ("spectroscopic_catalog", HDFFile),
     ]
     config_options = TXBaseLensSelector.config_options.copy()
     config_options.update({
@@ -502,6 +502,8 @@ class TXRandomForestLensSelector(TXBaseLensSelector):
         "chunk_rows": 10000,
         "lens_zbin_edges": [float],
         "random_seed": 42,
+        "spec_mag_column_format": "photometry/{band}",
+        "spec_redshift_column": "photometry/redshift",
     })
 
     def data_iterator(self):
@@ -516,9 +518,18 @@ class TXRandomForestLensSelector(TXBaseLensSelector):
             yield s, e, data
 
     def prepare_selector(self):
+        with self.open_input("spectroscopic_catalog") as spec_file:
+            training_data = read_training_data(
+                spec_file,
+                self.config["bands"],
+                self.config["spec_mag_column_format"],
+                self.config["spec_redshift_column"],
+            )
+
+
         return build_tomographic_classifier(
             self.config["bands"],
-            self.get_input("calibration_table"),
+            training_data,
             self.config["lens_zbin_edges"],
             self.config["random_seed"],
             self.comm,


### PR DESCRIPTION
The selectors have long used an old legacy ascii table that replicated RAIL's spectroscopic files. This changes them to read from those HDF files instead.