### PR TITLE
DES-Y3 3x2pt - lssweights speed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,6 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
-  workflow_dispatch:
   schedule:
     # run this every week at 12 noon on Monday
     - cron: '0 12 * * 1'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+  workflow_dispatch:
   schedule:
     # run this every week at 12 noon on Monday
     - cron: '0 12 * * 1'

--- a/txpipe/lsstools/__init__.py
+++ b/txpipe/lsstools/__init__.py
@@ -1,1 +1,1 @@
-from .lsstools import DensityCorrelation
+from .lsstools import DensityCorrelation, linear_model_from_maps

--- a/txpipe/lsstools/lsstools.py
+++ b/txpipe/lsstools/lsstools.py
@@ -55,6 +55,7 @@ class DensityCorrelation:
         sys_name=None,
         use_precompute=False,
         do_grid_hist=True, 
+        normalize=True, 
     ):
         """
         Add a 1d density correlation
@@ -83,6 +84,9 @@ class DensityCorrelation:
             If False will compute the density in bins using numpy histogram
         do_grid_hist: bool
             if True, will also compute a histogram of the SP map values (on a fine grid, equal spaced bins)
+        normalize: bool
+            If True, ndens is in dimentionless units (Nobj/Npix)/(np.sum(Nobj)/np.sum(Npix))
+            If False, ndens is in in units of object per pixel area (Nobj/Npix)
         """
         if sys_name is not None:
             self.mapnames[map_index] = str(sys_name)
@@ -133,6 +137,11 @@ class DensityCorrelation:
         # do we want to include any excluded outliers in this normalization?
         norm = np.ones(len(edges) - 1) * 1.0 / (np.sum(nobj_sys) / np.sum(npix_sys))
 
+        if normalize:
+            ndens = norm * nobj_sys / npix_sys
+        else:
+            ndens = nobj_sys / npix_sys
+
         self.map_index = np.append(self.map_index, np.ones(len(edges) - 1) * map_index)
         self.smin = np.append(self.smin, edges[:-1])
         self.smax = np.append(self.smax, edges[1:])
@@ -141,7 +150,7 @@ class DensityCorrelation:
         self.npix = np.append(self.npix, npix_sys)
         self.ndens_perpixel = np.append(self.ndens_perpixel, nobj_sys / npix_sys)
         self.norm = np.append(self.norm, norm)
-        self.ndens = np.append(self.ndens, norm * nobj_sys / npix_sys)
+        self.ndens = np.append(self.ndens, ndens)
 
     def precompute(self, map_index, edges, sys_vals, frac=None):
         """
@@ -543,8 +552,104 @@ class DensityCorrelation:
         self.add_external_covariance(density_correlation.covmat, assert_empty=True)
         self.add_model(density_correlation.ndens_models["null"], "null")
 
+    def precompute_design_matrix(self, sysmap_table_all, frac=None, corr_map_indices=None):
+        """
+        Precompute the design matrix for linear systematics regression.
 
-def linear_model(
+        For a linear model in map space:
+            F(x) = beta + alpha_0 * s_0(x) + alpha_1 * s_1(x) + ...
+
+        the mean of F over pixels in bin b of map j is:
+            <F>_{j,b} = beta + sum_i alpha_i * <s_i>_{j,b}
+
+        where <s_i>_{j,b} is the weighted mean of systematic map i over pixels
+        in bin b of map j. The full predicted data vector is then just A @ params,
+        where params = [beta, alpha_0, alpha_1, ...].
+
+        Parameters
+        ----------
+        sysmap_table_all : np.ndarray
+            Array of shape (N_maps, N_pix) containing systematic map values,
+            where the row index matches those in self.map_index
+        frac : np.ndarray, optional
+            Fractional pixel coverage, length N_pix. Defaults to ones.
+        corr_map_indicies : np.ndarray of its, optional
+            the indices for which we will compute the model 
+            (in the order they appear in the parameters array)
+            Defaults to all maps in DensityCorrelation
+
+        Returns
+        -------
+        design_matrix : np.ndarray
+            Array of shape (N_corr_maps * N_bins, N_corr_maps + 1) where N_corr_maps
+            is the number of maps to be used in the model. Row j*N_bins + b corresponds to bin
+            b of the jth correlation map. Column 0 is the beta (intercept) term
+            (all ones). Columns 1..N_maps contain the weighted mean of each
+            systematic map over the pixels in that bin.
+        """
+        if frac is None:
+            frac = np.ones(sysmap_table_all.shape[1])
+
+        if corr_map_indices is None:
+            # unique map indices in the order they were added
+            # If the DensityCorrelation object only uses a subset of sysmap_table,
+            # this should select only those rows that are used
+            _, first_occurrence = np.unique(self.map_index, return_index=True)
+            corr_map_indices = self.map_index[np.sort(first_occurrence)].astype(int)
+
+        n_corr_maps = len(corr_map_indices)
+        n_bins = len(self.get_edges(corr_map_indices[0])) - 1
+        A = np.zeros((n_corr_maps * n_bins, n_corr_maps + 1))
+        A[:, 0] = 1.0  # beta column
+
+        for j, map_index_j in enumerate(corr_map_indices): #For each map we are binning on...
+            edges_j = self.get_edges(map_index_j)
+            row_start = j * n_bins
+            row_end = row_start + n_bins
+
+            # weighted pixel count
+            weighted_pix_count, _ = np.histogram(
+                sysmap_table_all[map_index_j],
+                bins=edges_j,
+                weights=frac,
+            )
+
+            for i, map_index_i in enumerate(corr_map_indices): #... compute means of every other map in the model
+
+                #  weighted sum of systematic map i
+                sumsys, _ = np.histogram(
+                    sysmap_table_all[map_index_j],
+                    bins=edges_j,
+                    weights=sysmap_table_all[map_index_i] * frac,
+                )
+
+                A[row_start:row_end, i + 1] = sumsys / weighted_pix_count
+
+        self.design_matrix_corr_map_indices = np.asarray(corr_map_indices)
+        self.design_matrix = A
+        return A
+    
+    def linear_model(self, params):
+        """
+        linear contamination model:
+        F(s) = alpha1*s1 + alpha2*s2 + ... + beta
+
+        computes the model using precomputed design matrix
+
+        Parameters
+        ----------
+        params : np.ndarray
+            the input parameters [beta, alpha1, alpha2, ...]
+        
+        Returns
+        ----------
+            predicted_mean_F : np.ndarray
+                the predicted density model for this set of parameters
+        """
+        predicted_mean_F = self.design_matrix @ params
+        return predicted_mean_F
+
+def linear_model_from_maps(
     beta,
     *alphas,
     density_correlation=None,
@@ -587,26 +692,28 @@ def linear_model(
     Fvals = np.sum(np.array([alphas]).T * sysmap_table[map_index], axis=0) + beta
     F.update_values_pix(validpixels, Fvals)
 
-    # normalize the map
-    meanF = np.mean(F[validpixels])  # TODO make this a weighted mean?
-    F.update_values_pix(validpixels, F[validpixels] / meanF)
-
     data_vals = F[validpixels]
-    frac_vals = frac[validpixels]
+    if frac is None:
+        frac_vals = np.ones(len(validpixels))
+    else:
+        frac_vals = frac[validpixels]
     F_density_corrs = lsstools.DensityCorrelation()
     F_density_corrs.set_precompute(density_correlation)
     for imap in map_index:
         sys_vals = sysmap_table[imap]
         edges = density_correlation.get_edges(imap)
+        #use the map correlation method to compute the mean F in s bins
         F_density_corrs.add_correlation(
             imap,
             edges,
             sys_vals,
             data_vals,
             map_input=True,
-            use_precompute=True,
+            use_precompute=False,
             frac=frac_vals,
+            weight=frac_vals,
             do_grid_hist=do_grid_hist,
+            normalize=False
         )
 
     return F, F_density_corrs

--- a/txpipe/lssweights.py
+++ b/txpipe/lssweights.py
@@ -437,7 +437,8 @@ class TXLSSDensityNullTests(TXLSSDensityBase):
 
         if self.rank == 0:
             # flatten list of lists
-            results = [result for sublist in results for result in sublist]
+            if self.comm is not None:
+                results = [result for sublist in results for result in sublist]
             # open outdir density correlation file.
             # only the root process does any writing.
             with self.open_output("unweighted_density_correlation", wrapper=False) as dens_output:

--- a/txpipe/lssweights.py
+++ b/txpipe/lssweights.py
@@ -1117,7 +1117,8 @@ class TXLSSWeightsLinBinned(TXLSSWeights):
             print("{0} map(s) selected for correction".format(len(sig_map_index)))
 
             # get the frac det (TO DO: get frac only, dont need deltag)
-            _, frac = self.get_deltag(density_correlation.tomobin)
+            _, frac_map = self.get_deltag(density_correlation.tomobin)
+            frac = frac_map[self.sys_maps[0].valid_pixels]
 
             # initial parameters
             p0 = np.array([1.0] + [0.0] * len(sig_map_index))
@@ -1127,38 +1128,52 @@ class TXLSSWeightsLinBinned(TXLSSWeights):
             dc_covmat_masked = density_correlation.covmat[dc_mask].T[dc_mask].T
             dc_ndens_masked = density_correlation.ndens[dc_mask]
 
+            density_correlation.precompute_design_matrix(
+                sysmap_table_all, frac=frac, corr_map_indices=sig_map_index
+                )
+
             # negative log likelihood to be minimized
             def neg_log_like(params):
-                beta = params[0]
-                alphas = params[1:]
-                F, Fdc = lsstools.lsstools.linear_model(
-                    beta,
-                    *alphas,
-                    density_correlation=density_correlation,
-                    sys_maps=self.sys_maps,
-                    sysmap_table=sysmap_table_all,
-                    map_index=sig_map_index,
-                    frac=frac,
-                )
-                chi2 = calc_chi2(dc_ndens_masked, dc_covmat_masked, Fdc.ndens)
+                Fdc_ndens = density_correlation.linear_model(params)
+                chi2 = calc_chi2(dc_ndens_masked, dc_covmat_masked, Fdc_ndens)
                 return chi2 / 2.0
 
             minimize_output = scipy.optimize.minimize(neg_log_like, p0, method="Nelder-Mead")
             coeff = minimize_output.x
             coeff_cov = None
 
+            # Check the fast linear_model output from the likelihood matches 
+            # the one from computing the maps
+            beta = coeff[0]
+            alphas = coeff[1:]
+            _, Fdc = lsstools.lsstools.linear_model_from_maps(
+                beta,
+                *alphas,
+                density_correlation=density_correlation,
+                sys_maps=self.sys_maps,
+                sysmap_table=sysmap_table_all,
+                map_index=sig_map_index,
+                frac=frac_map,
+                do_grid_hist=False
+            )
+            assert np.allclose(
+                Fdc.ndens,
+                density_correlation.linear_model(coeff),
+                rtol=1e-10,
+                atol=1e-12,), "linear model output ndens differs between design_matrix computation computing from the maps directly"
+
             # make best fit model (including the maps that were not selected)
             # and add this best fit model to the DensityCorrelation instance
             best_fit = np.array([1.0] + [0.0] * len(self.sys_maps))
             best_fit[0] = coeff[0]
             best_fit[sig_map_index + 1] = coeff[1:]
-            mean_density_map_bf, Fdc_bf = lsstools.lsstools.linear_model(
+            mean_density_map_bf, Fdc_bf = lsstools.lsstools.linear_model_from_maps(
                 best_fit[0],
                 *best_fit[1:],
                 density_correlation=density_correlation,
                 sys_maps=self.sys_maps,
                 sysmap_table=sysmap_table_all,
-                frac=frac,
+                frac=frac_map,
             )
             density_correlation.add_model(Fdc_bf.ndens, "linear")
 

--- a/txpipe/test/test_lss_corr.py
+++ b/txpipe/test/test_lss_corr.py
@@ -1,0 +1,115 @@
+from ..lsstools import (
+    DensityCorrelation,
+    linear_model_from_maps,
+)
+import numpy as np
+import healsparse as hsp
+import numpy.testing
+
+def test_linear_model():
+    """
+    We implement a simple linear systematic model in two places
+    lsstools.DensityCorrelation.linear_model() (fast, used for fitting)
+    lsstools.linear_model_from_maps() (slow, used for making maps of the output model)
+    Here we test they give the same answers
+    """
+    nside_sparse = 128
+    nvalid = 1000
+    pixels = np.arange(100,100+nvalid)
+
+    #make 3 fake sp maps (uniform number between 0 and 1)
+    s1 = hsp.HealSparseMap.make_empty(32, nside_sparse, dtype=float)
+    s1.update_values_pix(pixels, np.random.rand(nvalid))
+    s2 = hsp.HealSparseMap.make_empty_like(s1)
+    s2.update_values_pix(pixels, np.random.rand(nvalid))
+    s3 = hsp.HealSparseMap.make_empty_like(s1)
+    s3.update_values_pix(pixels, np.random.rand(nvalid))
+    sysmaps = [s1,s2,s3]
+    sysmap_table = np.vstack([s1[pixels],s2[pixels],s3[pixels]])
+
+    #also make a fake frac map
+    frac_map = hsp.HealSparseMap.make_empty_like(s1)
+    frac_map.update_values_pix(pixels, np.random.rand(nvalid))
+    frac = frac_map[pixels]
+
+    #make a fake catalog 
+    nobj = 10000
+    pix_obj = np.random.choice(pixels, size=nobj, replace=True)
+    s1_obj = s1[pix_obj]
+    s2_obj = s2[pix_obj]
+    s3_obj = s3[pix_obj]
+
+    #make density correlation object and fill in the 1d correlations
+    ds = DensityCorrelation()
+
+    #s1
+    ds.add_correlation(
+        map_index=0, 
+        edges=np.linspace(0,1,11),
+        sys_vals=sysmap_table[0],
+        data=s1_obj,
+        map_input=False, 
+        frac=frac, 
+        weight=None,
+        sys_name="s1",
+        use_precompute=False,
+        do_grid_hist=False,
+        normalize=True,
+        )
+    ds.add_correlation(
+        map_index=1, 
+        edges=np.linspace(0,1,11),
+        sys_vals=sysmap_table[1],
+        data=s2_obj,
+        map_input=False, 
+        frac=frac, 
+        weight=None,
+        sys_name="s2",
+        use_precompute=False,
+        do_grid_hist=False,
+        normalize=True,
+        )
+    ds.add_correlation(
+        map_index=2, 
+        edges=np.linspace(0,1,11),
+        sys_vals=sysmap_table[2],
+        data=s3_obj,
+        map_input=False, 
+        frac=frac, 
+        weight=None,
+        sys_name="s3",
+        use_precompute=False,
+        do_grid_hist=False,
+        normalize=True,
+        )
+    
+    #These are the maps that were flagges as "significant" (by some separate process)
+    maps2correct = np.array([0,2])
+    
+    #example fit params
+    beta = 1.0
+    alpha1 = 0.1
+    alpha2 = 0.2
+    alphas = np.array([alpha1, alpha2])
+    params = np.array([beta, alpha1, alpha2])
+    
+    #run lsstools.DensityCorrelation.linear_model
+    A = ds.precompute_design_matrix(sysmap_table, frac=frac, corr_map_indices=maps2correct)
+    model_ndens_matrix = ds.linear_model(params)
+
+    #run lsstools.linear_model_from_maps
+    corrected_maps = np.array([0,1])
+    model_map, model_ds = linear_model_from_maps(
+        beta,
+        *alphas,
+        density_correlation=ds,
+        sys_maps=sysmaps,
+        sysmap_table=sysmap_table,
+        map_index=maps2correct,
+        frac=frac_map, 
+        do_grid_hist=True,
+    )
+    model_ndens_map = model_ds.ndens
+
+    numpy.testing.assert_allclose(model_ndens_matrix, model_ndens_map)
+


### PR DESCRIPTION
Updates to the DESY3 branch that speed up the binned weights regression

- likelihood used for regression is now computed using matrix multiplication instead of binning the SP maps every time, which speeds up the likelihood by orders of magnitude
- I added a pytest to check the new model gives the same answer as the old one
- fixed a bug in lssweights when running without mpi

tested on `examples/lssweights/des-y1/pipeline_binned.yml`
