### PR TITLE
Add dependency on older pzflow version

### DIFF
--- a/bin/environment-local.yml
+++ b/bin/environment-local.yml
@@ -48,6 +48,9 @@ dependencies:
     - glass==2023.7
     - git+https://github.com/beckermr/hybrideb@a3198ea5bc8175542b058e5c1289d910f05fd99d
     - pz-rail[algos] @ git+https://github.com/LSSTDESC/RAIL@v1.1.2
+    # RAIL is not yet updated for PZFLOW 4 and dependencies
+    # are not yet corrected either so we do it here.
+    - pzflow==3.4.*
     # Numpy has to be here to make sure that pypi doesn't
     # try to install a different version
     - numpy==2.3.*

--- a/bin/environment-perlmutter.yml
+++ b/bin/environment-perlmutter.yml
@@ -57,6 +57,9 @@ dependencies:
     - glass==2023.7
     - git+https://github.com/beckermr/hybrideb@a3198ea5bc8175542b058e5c1289d910f05fd99d
     - pz-rail[algos] @ git+https://github.com/LSSTDESC/RAIL@v1.1.2
+    # RAIL is not yet updated for PZFLOW 4 and dependencies
+    # are not yet corrected either so we do it here.
+    - pzflow==3.4.*
     # Numpy has to be here to make sure that pypi doesn't
     # try to install a different version
     - numpy==2.3.*


### PR DESCRIPTION
PZFlow has been updated but mainline rail has not caught up nor pinned an older version dep. Do so here.