### PR TITLE
Empty pixels in degraded masks

### DIFF
--- a/txpipe/mapping/basic_maps.py
+++ b/txpipe/mapping/basic_maps.py
@@ -294,6 +294,9 @@ def degrade_healsparse(hsp_map, degrade_nside, reduction, weight_map=None):
             # only select unique pixels in the degraded map (I'm not sure why they sometimes duplicate)
             degraded_pixels = np.unique(map_degraded_sum.valid_pixels)
 
+            # remove any pixels that have 0 sum
+            degraded_pixels = degraded_pixels[map_degraded_sum[degraded_pixels] != 0.]
+
             map_out = hsp.HealSparseMap.make_empty_like(map_degraded_sum)
             map_out.update_values_pix(
                 degraded_pixels,


### PR DESCRIPTION
fixed bug where empty pixels would appear in the mask with 0 weight, rather than using the UNSEEN value

This seems to be an issue within healsparse itself where the degrade method with reduction="sum" adds extra pixels with 0 sum. This PR just removes these pixels manually after the fact