### PR TITLE
anacal ingest bug correction

### DIFF
--- a/examples/anacal/config.yml
+++ b/examples/anacal/config.yml
@@ -5,8 +5,18 @@ global:
     nside: 512
 
 TXIngestAnacal:
-    bands: griz
-    collections: "u/xiangchl/dp1/a360_anacal2"
+    # DP1-v2 AnaCal outputs for the a360 cluster field (mergePatches per-tract).
+    butler_config_file: /global/cfs/cdirs/lsst/production/gen3/rubin/DP1/repo/butler.yaml
+    collections: "u/xiangchl/dp1-v2/a360_anacal2"
+
+    # a360 sits in the "Low Ecliptic Latitude Field" (LELF).  DP1_TRACTS["LELF"]
+    # contains the two live tracts 10463, 10464 (plus four never-processed).
+    select_field: "LELF"
     cosmology_tracts_only: False
+
+    # Merged catalog carries band-combined shape moments under the "fpfs1_*"
+    # prefix and Gaussian-aperture fluxes at scale "gauss2".  a360 was
+    # measured on griz only (no u/y coadds).
     prefix: "fpfs1"
-    scale: "fpfs1"
+    scale: "gauss2"
+    bands: "griz"

--- a/examples/anacal/pipeline.yml
+++ b/examples/anacal/pipeline.yml
@@ -14,7 +14,7 @@ site:
 modules: >
     txpipe
 
-config: examples/Anacal_test/config.yml
+config: examples/anacal/config.yml
 
 inputs:
     anacal_catalog: /pscratch/sd/x/xiangchl/data/DP1/catalogs/anacal_catalog_a360.fits

--- a/txpipe/data_types.py
+++ b/txpipe/data_types.py
@@ -108,7 +108,7 @@ class ShearCatalog(HDFFile):
         elif self.catalog_type == "metadetect":
             shear_cols = ["00/g1", "00/g2", "00/ra", "00/dec", "00/weight"]
             rename = {c: c[3:] for c in shear_cols}
-        elif self.catalog_type == "Anacal":
+        elif self.catalog_type == "anacal":
             shear_cols = ["e1", "e2", "ra", "dec", "weight"]
             rename = {"e1":"g1", "e2":"g2"}
         else:

--- a/txpipe/shear_calibration/calibration_calculators.py
+++ b/txpipe/shear_calibration/calibration_calculators.py
@@ -1010,7 +1010,7 @@ class AnaCalCalculator(CalibrationCalculator):
                 sum_sel_response_e1m1 = comm.reduce(self.sel_response_e1m1)
                 sum_sel_response_e2p2 = comm.reduce(self.sel_response_e2p2)
                 sum_sel_response_e2m2 = comm.reduce(self.sel_response_e2m2)
-                sum_det_response_e1 = comm.reduce(self.det_respponse_e1)
+                sum_det_response_e1 = comm.reduce(self.det_response_e1)
                 sum_det_response_e2 = comm.reduce(self.det_response_e2)
         else:
             count = self.count

--- a/txpipe/shear_calibration/calibration_calculators.py
+++ b/txpipe/shear_calibration/calibration_calculators.py
@@ -1036,8 +1036,8 @@ class AnaCalCalculator(CalibrationCalculator):
         R_shape = 0.5 * (mean_de1_dg1 + mean_de2_dg2)
         R_weight = 0.5 * (sum_det_response_e1 + sum_det_response_e2) / sum_weights
 
-        R_sel_1 = (sum_sel_response_e1p1 - sum_sel_response_e1m1) / (2.0 * self.delta_gamma) / count
-        R_sel_2 = (sum_sel_response_e2p2 - sum_sel_response_e2m2) / (2.0 * self.delta_gamma) / count
+        R_sel_1 = (sum_sel_response_e1p1 - sum_sel_response_e1m1) / (2.0 * self.delta_gamma) / sum_weights
+        R_sel_2 = (sum_sel_response_e2p2 - sum_sel_response_e2m2) / (2.0 * self.delta_gamma) / sum_weights
         R_sel = 0.5 * (R_sel_1 + R_sel_2)
 
         R_total = R_shape + R_weight + R_sel

--- a/txpipe/source_selection/Anacal.py
+++ b/txpipe/source_selection/Anacal.py
@@ -54,7 +54,7 @@ class TXSourceSelectorAnacal(TXSourceSelectorBase):
                       "weight_dg1",
                       "weight_dg2"
                       ]
-        shear_cols += band_variants(bands, "mag", "mag_err", shear_catalog_type="Anacal")
+        shear_cols += band_variants(bands, "mag", "mag_err", shear_catalog_type="anacal")
 
         if self.config["input_pz"]:
             shear_cols += ["mean_z"]

--- a/txpipe/utils/conversion.py
+++ b/txpipe/utils/conversion.py
@@ -24,9 +24,9 @@ def moments_to_shear(Ixx, Iyy, Ixy):
 
 
 def anacal_mag_response(flux, response):
-    mag_resp = np.divide( -2.5 / np.log(10) * response, 
-                         flux, 
-                         out=np.full_like(f, np.nan),
-                         where=f > 0
+    mag_resp = np.divide( -2.5 / np.log(10) * response,
+                         flux,
+                         out=np.full_like(flux, np.nan, dtype=np.float64),
+                         where=flux > 0,
                          )
     return mag_resp

--- a/txpipe/utils/conversion.py
+++ b/txpipe/utils/conversion.py
@@ -13,7 +13,11 @@ def mag_ab_to_nanojansky(mag):
 
 
 def nanojansky_err_to_mag_ab(flux, flux_err):
-    return 2.5 / np.log(10) * (flux_err / flux)
+    return np.divide(2.5 / np.log(10) * flux_err,
+                     flux,
+                     out=np.full_like(flux, np.nan, dtype=np.float64),
+                     where=flux > 0,
+                     )
 
 
 def moments_to_shear(Ixx, Iyy, Ixy):


### PR DESCRIPTION
1. unify shear_catalog_type to "anacal". There was 'Anacal' and 'anacal'
2. correct for the typo in calibration_calibrators.py, det_respponse_e1
3. in conversion.py f was not defined, changed to flux (https://github.com/LSSTDESC/TXPipe/pull/482#discussion_r3584799736)
4. The selection response was not correctly normalized, see explanation here: https://github.com/LSSTDESC/TXPipe/pull/482#discussion_r3585035981
5. The example file catalog directory was out-of-date (https://github.com/LSSTDESC/TXPipe/pull/482#discussion_r3585074869).