### PR TITLE
Replace mock noise generation with photerr

### DIFF
--- a/bin/environment-local.yml
+++ b/bin/environment-local.yml
@@ -23,6 +23,7 @@ dependencies:
   - namaster=2.5.*
   - numpy=2.3.*
   - pandas=2.3.*
+  - photerr=1.5.*
   - pip=25.*
   - psutil=7.1.*
   - pyccl=3.2.*

--- a/bin/environment-perlmutter.yml
+++ b/bin/environment-perlmutter.yml
@@ -24,6 +24,7 @@ dependencies:
   - namaster=2.5.*
   - numpy=2.3.*
   - pandas=2.3.*
+  - photerr=1.5.*
   - pip=25.*
   - psutil=7.1.*
   - pyccl=3.2.*

--- a/examples/2.2i/config.yml
+++ b/examples/2.2i/config.yml
@@ -13,7 +13,7 @@ TXIngestStars:
 
 TXCosmoDC2Mock:
     cat_name: cosmoDC2_v1.1.4_image
-    visits_per_band: 16
+    years: 1.0
     extra_cols: redshift_true size_true shear_1 shear_2
     flip_g2: true # to match metacal
 

--- a/examples/buzzard/config.yml
+++ b/examples/buzzard/config.yml
@@ -1,6 +1,6 @@
 TXBuzzardMock:
     cat_name: buzzard
-    visits_per_band: 16
+    years: 1.0
     extra_cols: redshift_true size_true shear_1 shear_2
     flip_g2: True # to match metacal
     max_npix: 4

--- a/examples/cosmodc2/config-20deg2.yml
+++ b/examples/cosmodc2/config-20deg2.yml
@@ -15,7 +15,7 @@ TXExposureInfo:
 
 TXCosmoDC2Mock:
     cat_name: cosmoDC2_v1.1.4_image
-    visits_per_band: 16
+    years: 1.0
     extra_cols: redshift_true size_true shear_1 shear_2 Mag_true_r_sdss_z0
     flip_g2: true # to match metacal
     snr_limit: 4.0

--- a/examples/cosmodc2/config.yml
+++ b/examples/cosmodc2/config.yml
@@ -14,7 +14,7 @@ TXShearCalibration: {}
 
 TXCosmoDC2Mock:
     cat_name: cosmoDC2_v1.1.4_image
-    visits_per_band: 16
+    years: 1.0
     extra_cols: redshift_true size_true shear_1 shear_2 Mag_true_r_sdss_z0
     flip_g2: true # to match metacal
     snr_limit: 4.0

--- a/examples/cosmodc2/config_no_shape_noise.yml
+++ b/examples/cosmodc2/config_no_shape_noise.yml
@@ -11,7 +11,7 @@ TXExposureInfo:
 
 TXCosmoDC2Mock:
     cat_name: cosmoDC2_v1.1.4_image
-    visits_per_band: 16
+    years: 1.0
     extra_cols: redshift_true size_true shear_1 shear_2 Mag_true_r_sdss_z0 
     flip_g2: True # to match metacal
     snr_limit: 4.0

--- a/examples/cosmodc2/ingest-small-config.yml
+++ b/examples/cosmodc2/ingest-small-config.yml
@@ -11,7 +11,7 @@ TXExposureInfo:
 
 TXCosmoDC2Mock:
     cat_name: cosmoDC2_v1.1.4_image
-    visits_per_band: 16
+    years: 1.0
     extra_cols: redshift_true size_true shear_1 shear_2 Mag_true_r_sdss_z0 
     flip_g2: True # to match metacal
     snr_limit: 4.0

--- a/examples/ext_cross_corr/config_1deg.yml
+++ b/examples/ext_cross_corr/config_1deg.yml
@@ -47,7 +47,7 @@ TXExposureInfo:
 
 TXCosmoDC2Mock:
     cat_name: cosmoDC2_v1.1.4_image
-    visits_per_band: 16
+    years: 1.0
     extra_cols: redshift_true size_true shear_1 shear_2
     flip_g2: True # to match metacal
 

--- a/examples/gaussian_sims/config.yml
+++ b/examples/gaussian_sims/config.yml
@@ -11,7 +11,7 @@ TXExposureInfo:
 TXGaussianSimsMock:
     #cat_name: '/global/cfs/cdirs/lsst/groups/WL/users/jprat/gaussian_sims_srdnzs_fullsky/051422/12300area/shearcat_allbins_ra_dec_e1_e2_and_fakecols_areacut.npy'
     cat_name: '/global/cfs/cdirs/lsst/groups/WL/users/jprat/gaussian_sims_srdnzs_fullsky/071222/shearcat_allbins_ra_dec_e1_e2_and_fakecols_12300d_withgalbias.npy'
-    visits_per_band: 16
+    years: 1.0
     extra_cols: redshift_true size_true shear_1 shear_2 
     flip_g2: False # opposite of cosmodc2
     snr_limit: 0.0 # we want to keep all galaxies

--- a/examples/hscy3/config.yml
+++ b/examples/hscy3/config.yml
@@ -25,7 +25,7 @@ TXExposureInfo:
 
 TXCosmoDC2Mock:
     cat_name: cosmoDC2_v1.1.4_image
-    visits_per_band: 16
+    years: 1.0
     extra_cols: redshift_true size_true shear_1 shear_2
     flip_g2: true # to match metacal
 

--- a/examples/lensfit/config.yml
+++ b/examples/lensfit/config.yml
@@ -17,7 +17,7 @@ TXExposureInfo:
 
 TXCosmoDC2Mock:
     cat_name: cosmoDC2_v1.1.4_image
-    visits_per_band: 16
+    years: 1.0
     extra_cols: redshift_true size_true shear_1 shear_2
     flip_g2: true # to match metacal
 

--- a/examples/metacal/config.yml
+++ b/examples/metacal/config.yml
@@ -23,7 +23,7 @@ TXExposureInfo:
 
 TXCosmoDC2Mock:
     cat_name: cosmoDC2_v1.1.4_image
-    visits_per_band: 16
+    years: 1.0
     extra_cols: redshift_true size_true shear_1 shear_2
     flip_g2: true # to match metacal
 

--- a/examples/metadetect/config.yml
+++ b/examples/metadetect/config.yml
@@ -26,7 +26,7 @@ TXExposureInfo:
 
 TXCosmoDC2Mock:
     cat_name: cosmoDC2_v1.1.4_image
-    visits_per_band: 16
+    years: 1.0
     extra_cols: redshift_true size_true shear_1 shear_2
     flip_g2: true # to match metacal
 

--- a/examples/metadetect_source_only/config.yml
+++ b/examples/metadetect_source_only/config.yml
@@ -23,7 +23,7 @@ TXExposureInfo:
 
 TXCosmoDC2Mock:
     cat_name: cosmoDC2_v1.1.4_image
-    visits_per_band: 16
+    years: 1.0
     extra_cols: redshift_true size_true shear_1 shear_2
     flip_g2: true # to match metacal
 

--- a/examples/redmagic/config.yml
+++ b/examples/redmagic/config.yml
@@ -24,7 +24,7 @@ TXShearCalibration: {}
 
 TXCosmoDC2Mock:
     cat_name: cosmoDC2_v1.1.4_image
-    visits_per_band: 16
+    years: 1.0
     extra_cols: redshift_true size_true shear_1 shear_2
     flip_g2: true # to match metacal
 

--- a/examples/skysim/config.yml
+++ b/examples/skysim/config.yml
@@ -14,7 +14,7 @@ TXExposureInfo:
 
 TXCosmoDC2Mock:
     cat_name: cosmoDC2_v1.1.4_image
-    visits_per_band: 16
+    years: 1.0
     extra_cols: redshift_true size_true shear_1 shear_2
     flip_g2: true # to match metacal
 

--- a/txpipe/ingest/mocks.py
+++ b/txpipe/ingest/mocks.py
@@ -29,7 +29,7 @@ class TXCosmoDC2Mock(PipelineStage):
 
     config_options = {
         "cat_name": StageParameter(str, "cosmoDC2", msg="Name of the mock catalog to use."),
-        "visits_per_band": StageParameter(int, 165, msg="Number of visits per band for noise simulation."),
+        "year": StageParameter(float, 1.0, msg="The number of years of data to simulate for noise"),
         "snr_limit": StageParameter(float, 4.0, msg="S/N limit for object selection."),
         "max_size": StageParameter(int, 99999999999999, msg="Maximum catalog size for testing."),
         "extra_cols": StageParameter(str, "", msg="Extra columns to include (space-separated)."),
@@ -414,9 +414,10 @@ class TXCosmoDC2Mock(PipelineStage):
 
     def make_mock_photometry(self, data):
         # The visit count affects the overall noise levels
-        n_visit = self.config["visits_per_band"]
+        n_year = self.config["years"]
+        unit_response = self.config["unit_response"]
         # Do all the work in the function below
-        photo = make_mock_photometry(n_visit, self.bands, data, self.config["unit_response"])
+        photo = make_mock_photometry(self.bands, data, unit_response, n_year)
 
         for col in self.config["extra_cols"].split():
             photo[col] = data[col]
@@ -425,7 +426,6 @@ class TXCosmoDC2Mock(PipelineStage):
 
     def make_mock_metadetect(self, data, photo):
         """
-        !!! This function is not working properly yet!!!
         Generate a mock metadetect table.
         This is a long and complicated function unfortunately.
 
@@ -1051,7 +1051,7 @@ class TXGaussianSimsMock(TXCosmoDC2Mock):
         return cat, N
 
 
-def make_mock_photometry(n_visit, bands, data, unit_response):
+def make_mock_photometry(bands, data, unit_response, years):
     """
     Generate a mock photometric table with noise added
 
@@ -1060,6 +1060,8 @@ def make_mock_photometry(n_visit, bands, data, unit_response):
     retrieved here:
     http://faculty.washington.edu/ivezic/Teaching/Astr511/LSST_SNRdoc.pdf
     """
+    import pandas as pd
+    import photerr
 
     output = {}
     nobj = data["galaxy_id"].size
@@ -1069,27 +1071,6 @@ def make_mock_photometry(n_visit, bands, data, unit_response):
     output["extendedness"] = np.ones(nobj)
     if "redshift_true" in data:
         output["redshift_true"] = data["redshift_true"]
-    # Sky background, seeing FWHM, and system throughput,
-    # all from table 2 of Ivezic, Jones, & Lupton
-    B_b = np.array([85.07, 467.9, 1085.2, 1800.3, 2775.7, 3614.3])
-    fwhm = np.array([0.77, 0.73, 0.70, 0.67, 0.65, 0.63])
-    T_b = np.array([0.0379, 0.1493, 0.1386, 0.1198, 0.0838, 0.0413])
-
-    # effective pixels size for a Gaussian PSF, from equation
-    # 27 of Ivezic, Jones, & Lupton
-    pixel = 0.2  # arcsec
-    N_eff = 2.436 * (fwhm / pixel) ** 2
-
-    # other numbers from Ivezic, Jones, & Lupton
-    sigma_inst2 = 10.0**2  # instrumental noise in photons per pixel, just below eq 42
-    gain = 1  # ADU units per photon, also just below eq 42
-    D = 6.5  # primary mirror diameter in meters, from LSST key numbers page (effective clear diameter)
-    # Not sure what effective clear diameter means but it's closer to the number used in the paper
-    time = 30.0  # seconds per exposure, from LSST key numbers page
-    sigma_b2 = 0.0  # error on background, just above eq 42
-
-    # combination of these  used below, from various equations
-    factor = 5455.0 / gain * (D / 6.5) ** 2 * (time / 30.0)
 
     # Fake some metacal responses
     if unit_response:
@@ -1101,62 +1082,38 @@ def make_mock_photometry(n_visit, bands, data, unit_response):
     # that's the right thing to use here because we are doing m+ = m0 + dm/dy*dy
     # Use the same response for gamma1 and gamma2
 
-    for band, b_b, t_b, n_eff, mag_resp in zip(bands, B_b, T_b, N_eff, mag_responses):
-        # truth magnitude
-        mag = data[f"mag_true_{band}_lsst"]
-        output[f"mag_true_{band}_lsst"] = mag
+    df = pd.DataFrame.from_dict({
+        b: data[f"mag_true_{b}_lsst"]
+        for b in bands
+    })
+    error_model = photerr.LsstErrorModel(nYrObs=years)
+    noisy_df = error_model(df)
 
-        # expected signal photons, over all visits
-        c_b = factor * 10 ** (0.4 * (25 - mag)) * t_b * n_visit
+    for i, b in enumerate(bands):
+        mag_obs = np.array(noisy_df[b])
+        mag_err = np.array(noisy_df[b + "_err"])
+        output[f"mag_{b}"] = mag_obs
+        output[f"mag_err_{b}"] = mag_err
+        m = mag_responses[i] * delta_gamma
+ 
+        output[f"mag_{b}_1p"] = mag_obs + m
+        output[f"mag_{b}_1m"] = mag_obs - m
+        output[f"mag_{b}_2p"] = mag_obs + m
+        print(b)
+        print("True", data[f"mag_true_{b}_lsst"])
+        print("Obs", np.array(output[f"mag_{b}"]))
+        print("ObErrs", np.array(output[f"mag_err_{b}"]))
+        print("")
+        output[f"mag_{b}_2m"] = mag_obs - m
 
-        # expected background photons, over all visits
-        background = np.sqrt((b_b + sigma_inst2 + sigma_b2) * n_eff * n_visit)
-        # total expected photons
-        mu = c_b + background
-
-        # Observed number of photons in excess of the expected background.
-        # This can go negative for faint magnitudes, indicating that the object is
-        # not going to be detected
-        n_obs = np.random.poisson(mu) - background
-        n_obs_err = np.sqrt(mu)
-
-        # signal to noise, true and estimated values
-        true_snr = c_b / background
-        obs_snr = n_obs / background
-
-        # observed magnitude from inverting c_b expression above
-        mag_obs = 25 - 2.5 * np.log10(n_obs / factor / t_b / n_visit)
-
-        # converting error on n_obs to error on mag
-        mag_err = 2.5 / np.log(10.0) / obs_snr
-
-        output[f"true_snr_{band}"] = true_snr
-        output[f"snr_{band}"] = obs_snr
-        output[f"mag_{band}"] = mag_obs
-        output[f"mag_err_{band}"] = mag_err
-        output[f"mag_{band}_err"] = mag_err
-
-        m = mag_resp * delta_gamma
-
-        m1 = mag_obs + m
-        m2 = mag_obs - m
-        mag_obs_1p = m1
-        mag_obs_1m = m2
-
-        output[f"mag_{band}_1p"] = m1
-        output[f"mag_{band}_1m"] = m2
-        output[f"mag_{band}_2p"] = m1
-        output[f"mag_{band}_2m"] = m2
-
-        # Scale the SNR values according the to change in magnitude.r
+        snr = 2.5 / np.log(10) /   mag_err
         s = np.power(10.0, -0.4 * m)
+        output[f"snr_{b}"] = snr
+        output[f"snr_{b}_1p"] = snr * s
+        output[f"snr_{b}_1m"] = snr / s
+        output[f"snr_{b}_2p"] = snr * s
+        output[f"snr_{b}_2m"] = snr / s
 
-        snr1 = obs_snr * s
-        snr2 = obs_snr / s
-        output[f"snr_{band}_1p"] = snr1
-        output[f"snr_{band}_1m"] = snr2
-        output[f"snr_{band}_2p"] = snr1
-        output[f"snr_{band}_2m"] = snr2
 
     return output
 
@@ -1272,18 +1229,27 @@ class TXMockTruthPZ(PipelineStage):
 
 
 def test():
-    import pylab
+    import matplotlib.pyplot as plt
 
+    n = 100_000
     data = {
-        "ra": None,
-        "dec": None,
-        "galaxy_id": None,
+        "ra": np.zeros(n),
+        "dec": np.zeros(n),
+        "galaxy_id": np.zeros(n),
     }
     bands = "ugrizy"
-    n_visit = 165
-    M5 = [24.22, 25.17, 24.74, 24.38, 23.80]
-    for b, m5 in zip(bands, M5):
-        data[f"mag_true_{b}_lsst"] = np.repeat(m5, 10000)
-    results = make_mock_photometry(n_visit, bands, data, True)
-    pylab.hist(results["snr_r"], bins=50, histtype="step")
-    pylab.savefig("snr_r.png")
+
+    years = 1
+    unit_response = True
+    for b in bands:
+        data[f"mag_true_{b}_lsst"] = np.arange(19, 30, 0.01)
+    results = make_mock_photometry(bands, data, unit_response, years)
+    for b in bands:
+        plt.figure()
+        plt.plot(data[f"mag_true_{b}_lsst"], results[f"snr_{b}"], ',')
+        plt.savefig(f"snr_{b}.png")
+        plt.close()
+        plt.figure()
+        plt.plot(data[f"mag_true_{b}_lsst"], results[f"mag_{b}"], ',')
+        plt.savefig(f"mag_{b}.png")
+        plt.close()

--- a/txpipe/ingest/mocks.py
+++ b/txpipe/ingest/mocks.py
@@ -29,7 +29,7 @@ class TXCosmoDC2Mock(PipelineStage):
 
     config_options = {
         "cat_name": StageParameter(str, "cosmoDC2", msg="Name of the mock catalog to use."),
-        "year": StageParameter(float, 1.0, msg="The number of years of data to simulate for noise"),
+        "years": StageParameter(float, 1.0, msg="The number of years of data to simulate for noise"),
         "snr_limit": StageParameter(float, 4.0, msg="S/N limit for object selection."),
         "max_size": StageParameter(int, 99999999999999, msg="Maximum catalog size for testing."),
         "extra_cols": StageParameter(str, "", msg="Extra columns to include (space-separated)."),
@@ -930,7 +930,7 @@ class TXBuzzardMock(TXCosmoDC2Mock):
 
     config_options = {
         "cat_name": StageParameter(str, "buzzard", msg="Name of the mock catalog to use."),
-        "visits_per_band": StageParameter(int, 165, msg="Number of visits per band for noise simulation."),
+        "years": StageParameter(float, 1.0, msg="Number of years of data for noise simulation."),
         "snr_limit": StageParameter(float, 4.0, msg="S/N limit for object selection."),
         "max_size": StageParameter(int, 99999999999999, msg="Maximum catalog size for testing."),
         "extra_cols": StageParameter(str, "", msg="Extra columns to include (space-separated)."),
@@ -964,7 +964,7 @@ class TXGaussianSimsMock(TXCosmoDC2Mock):
 
     config_options = {
         "cat_name": StageParameter(str, "GaussianSims", msg="Name of the Gaussian simulation catalog."),
-        "visits_per_band": StageParameter(int, 165, msg="Number of visits per band for noise simulation."),
+        "years": StageParameter(float, 1.0, msg="Number of years of data for noise simulation."),
         "snr_limit": StageParameter(float, 0.0, msg="S/N limit for object selection (0 for all)."),
         "max_size": StageParameter(int, 99999999999999, msg="Maximum catalog size for testing."),
         "extra_cols": StageParameter(str, "", msg="Extra columns to include (space-separated)."),
@@ -1245,9 +1245,11 @@ class TXMockTruthPZ(PipelineStage):
 
 
 def test():
+    import matplotlib
+    matplotlib.use("agg")
     import matplotlib.pyplot as plt
 
-    n = 100_000
+    n = 1000
     data = {
         "ra": np.zeros(n),
         "dec": np.zeros(n),
@@ -1258,7 +1260,7 @@ def test():
     years = 1
     unit_response = True
     for b in bands:
-        data[f"mag_true_{b}_lsst"] = np.arange(19, 30, 0.01)
+        data[f"mag_true_{b}_lsst"] = np.linspace(19, 30, n)
     results = make_mock_photometry(bands, data, unit_response, years)
     for b in bands:
         plt.figure()

--- a/txpipe/ingest/mocks.py
+++ b/txpipe/ingest/mocks.py
@@ -280,7 +280,7 @@ class TXCosmoDC2Mock(PipelineStage):
         ) + band_variants("riz", "mag", "mag_err", shear_catalog_type="metadetect")
 
         # Store the truth shear only for the primary catalog, true redshift for all variants
-        cols += ["00/true_g1", "00/true_g2"] + metadetect_variants("redshift_true")
+        cols += ["ns/true_g1", "ns/true_g2"] + metadetect_variants("redshift_true")
 
         # Make group for all the photometry
         group = metacal_file.create_group("shear")

--- a/txpipe/ingest/mocks.py
+++ b/txpipe/ingest/mocks.py
@@ -1094,19 +1094,35 @@ def make_mock_photometry(bands, data, unit_response, years):
         mag_err = np.array(noisy_df[b + "_err"])
         output[f"mag_{b}"] = mag_obs
         output[f"mag_err_{b}"] = mag_err
+
+        # The response is d(mag)/d(gamma), so this
+        # m value gives us delta_mag
         m = mag_responses[i] * delta_gamma
  
+        # Assume that the response is simple, i.e.
+        # that m_00 == m_11 and m_01 == m_10 == 0.
+        # In that case the 1p and 2p are the same,
+        # as are the 1m and 2m.
         output[f"mag_{b}_1p"] = mag_obs + m
         output[f"mag_{b}_1m"] = mag_obs - m
         output[f"mag_{b}_2p"] = mag_obs + m
-        print(b)
-        print("True", data[f"mag_true_{b}_lsst"])
-        print("Obs", np.array(output[f"mag_{b}"]))
-        print("ObErrs", np.array(output[f"mag_err_{b}"]))
-        print("")
         output[f"mag_{b}_2m"] = mag_obs - m
 
-        snr = 2.5 / np.log(10) /   mag_err
+        # Convert from magnitude error to
+        # SNR. This just comes from flux/flux_err
+        # See conversion.py for more.
+        snr = 2.5 / np.log(10) / mag_err
+        # We would like the SNR to vary with
+        # the applied shear too. In our approximation
+        # here the flux error doesn't vary with the
+        # shear, just the flux itself.
+        # So snr_1p / snr = f_1p / f
+        #                 = 10^{-0.4 M_1p} / 10^{-0.4 M}
+        #                 = 10^{-0.4 (M_1p - M)}
+        #                 = 10^{-0.4 m}
+        # This isn't the best way to do this but is adequate
+        # for our purposes here (you can also construct df/dgamma
+        # instead of using the dM = delta M approximation)
         s = np.power(10.0, -0.4 * m)
         output[f"snr_{b}"] = snr
         output[f"snr_{b}_1p"] = snr * s

--- a/txpipe/test/test_misc.py
+++ b/txpipe/test/test_misc.py
@@ -1,6 +1,8 @@
 from ..utils.misc import unique_list
+from ..ingest.mocks import test as run_test_mock_noise
+import os
 import numpy as np
-
+import tempfile
 
 def test_unique_list():
     x = [1, 1, 1, 1]
@@ -14,3 +16,15 @@ def test_unique_list():
 
     x = [-1, "cat", -1, "cat", "dog"]
     assert unique_list(x) == [-1, "cat", "dog"]
+
+def test_mock_noise():
+    cwd = os.getcwd()
+    with tempfile.TemporaryDirectory() as dirname:
+        try:
+            os.chdir(dirname)
+            run_test_mock_noise()
+            for b in "ugrizy":
+                assert os.path.exists(f"snr_{b}.png")
+                assert os.path.exists(f"mag_{b}.png")
+        finally:
+            os.chdir(cwd)


### PR DESCRIPTION
The previous code for adding noise to the CosmoDC2 catalogs or Gaussian sims used an implementation with some very old numbers in. This replaces them with the PhotErr package.